### PR TITLE
Add Markov future price model

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -33,6 +33,7 @@ include("models/hybrid/CompositeModel.jl")
 include("models/hybrid/SimpleModel.jl")
 include("models/rates/SeparableHjmModel.jl")
 include("models/rates/GaussianHjmModel.jl")
+include("models/futures/MarkovFutureModels.jl")
 
 include("simulations/RandomNumbers.jl")
 include("simulations/Simulation.jl")

--- a/src/models/futures/MarkovFutureModels.jl
+++ b/src/models/futures/MarkovFutureModels.jl
@@ -1,0 +1,229 @@
+
+"""
+    struct MarkovFutureModel <: SeparableHjmModel
+        hjm_model::GaussianHjmModel
+    end
+
+A Markov model for Future prices with piece-wise constant benchmark
+price volatility and constant mean reversion.
+
+We implement an object adapter for the `GaussianHjmModel` to re-use
+implementation for common modelling parts.
+
+The `MarkovFutureModel` differs from the `GaussianHjmModel` essentially
+only by the drift Theta.
+
+Moreover, we do not require the integrated state variable and want to
+identify correlations with Future prices instead of forward rates.
+"""
+struct MarkovFutureModel <: SeparableHjmModel
+    hjm_model::GaussianHjmModel
+    state_alias::AbstractVector
+    factor_alias::AbstractVector
+end
+
+"""
+    markov_future_model(
+        alias::String,
+        delta::ParameterTermstructure,
+        chi::ParameterTermstructure,
+        sigma_f::BackwardFlatVolatility,
+        correlation_holder::Union{CorrelationHolder, Nothing},
+        quanto_model::Union{AssetModel, Nothing},
+        )
+
+Create a Gausian Markov model for Future prices.
+"""
+function markov_future_model(
+    alias::String,
+    delta::ParameterTermstructure,
+    chi::ParameterTermstructure,
+    sigma_f::BackwardFlatVolatility,
+    correlation_holder::Union{CorrelationHolder, Nothing},
+    quanto_model::Union{AssetModel, Nothing},
+    )
+    #
+    hjm_model = gaussian_hjm_model(alias, delta, chi, sigma_f, correlation_holder, quanto_model)
+    # manage aliases different to GaussianHjmModel
+    state_alias  = [ alias * "_x_" * string(k) for k in 1:length(delta()) ]
+    factor_alias = [ alias * "_f_" * string(k) for k in 1:length(delta()) ]  # ensure consistency with HJM correlation calculation
+    return MarkovFutureModel(hjm_model, state_alias, factor_alias)
+end
+
+
+"""
+    parameter_grid(m::MarkovFutureModel)
+
+Return a list of times representing the (joint) grid points of piece-wise
+constant model parameters.
+
+This method is intended to be used in conjunction with time-integration
+mehods that require smooth integrand functions.
+"""
+function parameter_grid(m::MarkovFutureModel)
+    return parameter_grid(m.hjm_model)
+end
+
+
+"""
+    chi_hjm(m::MarkovFutureModel)
+
+Return vector of constant mean reversion rates.
+"""
+function chi_hjm(m::MarkovFutureModel)
+    return chi_hjm(m.hjm_model)
+end
+
+"""
+    benchmark_times(m::MarkovFutureModel)
+
+Return vector of reference/benchmark times
+"""
+function benchmark_times(m::MarkovFutureModel)
+    return benchmark_times(m.hjm_model)
+end
+
+"""
+    alias(m::MarkovFutureModel)
+
+Return the model's own alias. This is the default implementation.
+"""
+function alias(m::MarkovFutureModel)
+    return alias(m.hjm_model)
+end
+
+"""
+    state_dependent_Theta(m::MarkovFutureModel)
+
+Return whether Theta requires a state vector input X.
+"""
+state_dependent_Theta(m::MarkovFutureModel) = state_dependent_Theta(m.hjm_model)
+
+"""
+    state_alias_H(m::MarkovFutureModel)
+
+Return a list of state alias strings required for (H * X) calculation.
+"""
+state_alias_H(m::MarkovFutureModel) = state_alias(m)
+
+"""
+    state_dependent_H(m::MarkovFutureModel)
+
+Return whether H requires a state vector input X.
+"""
+state_dependent_H(m::MarkovFutureModel) = state_dependent_H(m.hjm_model)
+
+"""
+    factor_alias_Sigma(m::MarkovFutureModel)
+
+Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.
+"""
+factor_alias_Sigma(m::MarkovFutureModel) = factor_alias(m)
+
+"""
+    state_dependent_Sigma(m::MarkovFutureModel)
+
+Return whether Sigma requires a state vector input X.
+"""
+state_dependent_Sigma(m::MarkovFutureModel) = state_dependent_Sigma(m.hjm_model)
+
+
+"""
+    Theta(
+        m::MarkovFutureModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return the deterministic drift component for simulation over the time period [s, t].
+If Theta is state-dependent a state vector X must be supplied. The method returns a
+vector of length(state_alias).
+"""
+function Theta(
+    m::MarkovFutureModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_Theta(m)
+    y(t) = func_y(m.hjm_model, t)
+    # make sure we do not apply correlations twice in quanto adjustment!
+    sigma_T_hyb(u) = m.hjm_model.sigma_T.HHfInv .* reshape(m.hjm_model.sigma_T.sigma_f(u), (1,:))
+    alpha = quanto_drift(m.factor_alias, m.hjm_model.quanto_model, s, t, X)
+    #
+    chi = chi_hjm(m)
+    one = ones(length(chi))
+    #
+    f(u) = begin
+        σT = m.hjm_model.sigma_T(u)  # w/ correlation
+        σT_hyb = sigma_T_hyb(u)      # w/o correlation
+        α = alpha(u)                 # w/ correlation
+        return 0.5 * H_hjm(chi,u,t) .* (y(u)*chi - σT*(σT'*one) - 2.0*σT_hyb*α)
+    end
+    Θ = _vector_integral(f, s, t, parameter_grid(m))
+    return Θ
+end
+
+
+"""
+    H_T(
+        m::MarkovFutureModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return the transposed of the convection matrix H for simulation over the time period
+[s, t].
+"""
+function H_T(
+    m::MarkovFutureModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_H(m)
+    chi = chi_hjm(m)
+    return sparse(1:length(chi), 1:length(chi), H_hjm(chi,s,t))
+end
+
+
+"""
+    Sigma_T(
+        m::MarkovFutureModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return a matrix-valued function representing the volatility matrix function.
+"""
+function Sigma_T(
+    m::MarkovFutureModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_Sigma(m)
+    chi = chi_hjm(m)
+    # make sure we do not apply correlations twice!
+    f(u) = H_hjm(chi,u,t) .* m.hjm_model.sigma_T.HHfInv .* reshape(m.hjm_model.sigma_T.sigma_f(u), (1,:))
+    return f
+end
+
+
+"""
+    log_future(m::MarkovFutureModel, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+
+Calculate the Future price term (h(t,T)'[x(t) + 0.5y(t)(1 - h(t,T))])'.
+"""
+function log_future(m::MarkovFutureModel, model_alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+    @assert alias(m) == model_alias
+    idx = X.idx[state_alias(m)[1]]
+    d = length(state_alias(m))
+    x = X.X[idx:idx+(d-1),:]
+    y = func_y(m.hjm_model, t)
+    h = H_hjm(m, t, T)
+    return (x .+ 0.5 * y * (1.0 .- h))' * h
+end

--- a/src/models/hybrid/CompositeModel.jl
+++ b/src/models/hybrid/CompositeModel.jl
@@ -69,6 +69,14 @@ function log_zero_bond(m::CompositeModel, alias::String, t::ModelTime, T::ModelT
     return log_zero_bond(m.models[m.model_dict[alias]], alias, t, T, X)
 end
 
+"""
+    log_future(m::CompositeModel, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+
+Calculate the Future price term h(t,T)'[x(t) + 0.5y(t)(1 - h(t,T))].
+"""
+function log_future(m::CompositeModel, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+    return log_future(m.models[m.model_dict[alias]], alias, t, T, X)
+end
 
 """
     state_dependent_Theta(m::CompositeModel)

--- a/test/unittests/models/futures/futures.jl
+++ b/test/unittests/models/futures/futures.jl
@@ -3,6 +3,6 @@ using Test
 
 @testset "Models for prices of futures" begin
 
-    # Add tests here.
+    include("markov_future_model.jl")
 
 end

--- a/test/unittests/models/futures/markov_future_model.jl
+++ b/test/unittests/models/futures/markov_future_model.jl
@@ -1,0 +1,116 @@
+
+using DiffFusion
+using LinearAlgebra
+using Test
+
+@testset "Markov Future model methods." begin
+
+    delta = DiffFusion.flat_parameter("Std", [ 1., 7., 15. ])
+    chi = DiffFusion.flat_parameter("Std", [ 0.01, 0.10, 0.30 ])
+    times =  [ 1., 2., 5., 10. ]
+    values = [ 50. 60. 70. 80.;
+               60. 70. 80. 90.;
+               70. 80. 90. 90.]
+    sigma_F = DiffFusion.backward_flat_volatility("Std",times,values)
+
+    @testset "Model setup." begin
+        m = DiffFusion.markov_future_model("Std",delta,chi,sigma_F,nothing,nothing)
+        @test DiffFusion.alias(m) == "Std"
+        @test DiffFusion.state_alias(m)  == [ "Std_x_1", "Std_x_2", "Std_x_3", ]
+        @test DiffFusion.factor_alias(m) == [ "Std_f_1", "Std_f_2", "Std_f_3", ]
+        HHfInv = DiffFusion.benchmark_times_scaling(chi(),delta())
+        @test m.hjm_model.sigma_T(1.5) == HHfInv * Diagonal([60., 70., 80.])
+        @test m.hjm_model.sigma_T(5.0) == HHfInv * Diagonal([70., 80., 90.])
+        @test m.hjm_model.sigma_T(12.0) == HHfInv * Diagonal([80., 90., 90.])
+        #
+        @test_throws AssertionError DiffFusion.markov_future_model("Std", DiffFusion.flat_parameter("", delta()[2:end]), chi, sigma_F, nothing, nothing)
+        @test_throws AssertionError DiffFusion.markov_future_model("Std", delta, DiffFusion.flat_parameter("", chi()[2:end]), sigma_F, nothing, nothing)
+        @test_throws AssertionError DiffFusion.markov_future_model("Std", DiffFusion.flat_parameter("", reverse(delta())), chi, sigma_F, nothing, nothing)
+        @test_throws AssertionError DiffFusion.markov_future_model("Std", delta, DiffFusion.flat_parameter("", reverse(chi())), sigma_F, nothing, nothing)
+    end
+
+    @testset "Model Correlation." begin
+        ch = DiffFusion.correlation_holder("Std")
+        DiffFusion.set_correlation!(ch, "Std_f_1", "Std_f_2", 0.80)
+        DiffFusion.set_correlation!(ch, "Std_f_2", "Std_f_3", 0.80)
+        DiffFusion.set_correlation!(ch, "Std_f_1", "Std_f_3", 0.50)
+        m_wo_corr = DiffFusion.markov_future_model("Std",delta,chi,sigma_F, nothing, nothing)  
+        m_w_corr = DiffFusion.markov_future_model("Std",delta,chi,sigma_F, ch, nothing)
+        S1 = m_wo_corr.hjm_model.sigma_T(1.5)
+        S2 = m_w_corr.hjm_model.sigma_T(1.5)
+        G = [ 1.0 0.8 0.5;
+              0.8 1.0 0.8;
+              0.5 0.8 1.0]
+        L = cholesky(G).L
+        @test isapprox(S1 * L, S2, atol=1.0e-12)
+    end
+
+    @testset "Theta calculation." begin
+        m = DiffFusion.markov_future_model("Theta_3F",delta,chi,sigma_F,nothing,nothing)
+        @test_nowarn DiffFusion.Theta(m, 0.0, 1.0)
+        @test_nowarn DiffFusion.Theta(m, 1.0, 2.0)
+        @test_nowarn DiffFusion.Theta(m, 2.0, 3.5)
+        @test_nowarn DiffFusion.Theta(m, 2.0, 5.0)
+        @test_nowarn DiffFusion.Theta(m, 5.0, 10.0)
+        @test_nowarn DiffFusion.Theta(m, 1.0, 15.0)
+        # test against manual calculation model
+        theta_times = [ (0.0, 1.0), (1.0, 2.0), (6.0, 10.0), (0.5, 3.5), (2.5, 12.5) ]
+        theta_model = [ DiffFusion.Theta(m, s, t) for (s,t) in theta_times ]
+        # display(theta_model)
+        y(u) = DiffFusion.func_y(m.hjm_model, u)
+        σT(u) = m.hjm_model.sigma_T(u)
+        χ = m.hjm_model.chi()
+        for ((s, t), Θ) in zip(theta_times, theta_model)
+            f(u) = DiffFusion.H_hjm(m.hjm_model,u,t).*(y(u)*χ - vec(sum(σT(u) * σT(u)', dims=2)))
+            Θ_ref = 0.5 * DiffFusion._vector_integral(f, s, t)
+            @test isapprox(Θ, Θ_ref, rtol=1.0e-8)
+        end
+    end
+
+    @testset "H calculation." begin
+        m = DiffFusion.markov_future_model("Theta_3F",delta,chi,sigma_F,nothing,nothing)
+        H = DiffFusion.H_T(m, 0.5, 2.5)
+        @test size(H) == (3, 3)
+        times = [ (0.0, 1.0), (1.0, 2.0), (6.0, 10.0), (0.5, 3.5), (2.5, 12.5) ]
+        mkv_model = [ DiffFusion.H_T(m, s, t) for (s,t) in times ]
+        hjm_model = [ DiffFusion.H_T(m.hjm_model, s, t) for (s,t) in times ]
+        for (H_mkv, H_hjm) in zip(mkv_model, hjm_model)
+            @test H_mkv == H_hjm[1:3, 1:3]
+        end
+    end
+
+    @testset "Sigma calculation." begin
+        m = DiffFusion.markov_future_model("Theta_3F",delta,chi,sigma_F,nothing,nothing)
+        Σ = DiffFusion.Sigma_T(m, 0.5, 2.5)(1.0)
+        @test size(Σ) == (3, 3)
+        times = [ (0.0, 1.0), (1.0, 2.0), (6.0, 10.0), (0.5, 3.5), (2.5, 12.5) ]
+        mkv_model = [ DiffFusion.Sigma_T(m, s, t)(0.5*(s+t)) for (s,t) in times ]
+        hjm_model = [ DiffFusion.Sigma_T(m.hjm_model, s, t)(0.5*(s+t)) for (s,t) in times ]
+        for (Σ_mkv, Σ_hjm) in zip(mkv_model, hjm_model)
+            @test isapprox(Σ_mkv, Σ_hjm[1:3, 1:3], atol=1.0e-13)
+            # display(Σ_mkv - Σ_hjm[1:3, 1:3])
+        end
+    end
+
+    @testset "Model functions" begin
+        m = DiffFusion.markov_future_model("NIK", delta, chi, sigma_F, nothing, nothing)
+        y = DiffFusion.func_y(m.hjm_model, 4.0)
+        h = DiffFusion.H_hjm(m, 4.0, 8.0)
+        X = [ 1., 2., 3. ] * [ 1., 2., 3., 4.]'
+        dict = DiffFusion.alias_dictionary(DiffFusion.state_alias(m))
+        SX = DiffFusion.model_state(X, dict)
+        @test_throws AssertionError DiffFusion.log_future(m, "WrongAlias", 4.0, 8.0, SX)
+        #
+        X = [ 0., 0., 1., 2., 3., 0. ] * [ 1., 2., 3., 4. ]'
+        s_alias = [ "1", "2", "NIK_x_1", "NIK_x_2", "NIK_x_3", "6" ]
+        dict = DiffFusion.alias_dictionary(s_alias)
+        SX = DiffFusion.model_state(X, dict)
+        @test DiffFusion.log_future(m, "NIK", 4.0, 8.0, SX) == (X[3:5,:] .+ 0.5*y*(1.0 .- h))' * h
+        #
+        s_alias = [ "1", "2", "NIK_x_0", "NIK_x_2", "NIK_x_3", "6" ]
+        dict = DiffFusion.alias_dictionary(s_alias)
+        SX = DiffFusion.model_state(X, dict)
+        @test_throws KeyError DiffFusion.log_future(m, "NIK", 4.0, 8.0, SX)
+    end
+
+end

--- a/test/unittests/simulations/markov_future_model.jl
+++ b/test/unittests/simulations/markov_future_model.jl
@@ -1,0 +1,98 @@
+
+using DiffFusion
+using StatsBase
+using Test
+
+@testset "Markov Future model simulation." begin
+
+    ch = DiffFusion.correlation_holder("Std")
+    DiffFusion.set_correlation!(ch, "NIK_f_1", "NIK_f_2", 0.8)
+    DiffFusion.set_correlation!(ch, "NIK_f_2", "NIK_f_3", 0.8)
+    DiffFusion.set_correlation!(ch, "NIK_f_1", "NIK_f_3", 0.5)
+    #
+    DiffFusion.set_correlation!(ch, "EUR-USD_x", "NIK_f_1", -0.40)
+    DiffFusion.set_correlation!(ch, "EUR-USD_x", "NIK_f_2", -0.40)
+    DiffFusion.set_correlation!(ch, "EUR-USD_x", "NIK_f_3", -0.40)
+    #
+    delta = DiffFusion.flat_parameter([ 1., 7., 15. ])
+    chi = DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ])
+    times =  [ 1., 2., 5., 10. ]
+    values = [ 50. 60. 70. 80.;
+               60. 70. 80. 90.;
+               70. 80. 90. 90.] * 0.25 * 1.0e-2
+    sigma_f = DiffFusion.backward_flat_volatility("", times, values)
+
+    times =  [ 1., 2., 5., 10. ]
+    values = [ 15. 10. 20. 30.; ] * 1.0e-2
+    sigma_fx = DiffFusion.backward_flat_volatility("EUR-USD",times,values)
+
+    @testset "Simple simulation (no correlation)." begin
+        model = DiffFusion.markov_future_model("NIK-no-corr",delta,chi,sigma_f,ch,nothing)
+        times = 0.0:2.0:10.0
+        n_paths = 2^10
+        sobol = DiffFusion.sobol_brownian_increments
+        sim = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false, brownian_increments=sobol)
+        @test size(sim.X) == (3,1024,6)
+        # martingale test for Future price
+        dt_ = [ 0.0, 1.0, 2.0, 5.0, 10.0 ]
+        for (k, t) in enumerate(sim.times)
+            for dt in dt_
+                H = DiffFusion.H_hjm(model, t, t+dt)
+                I = ones(3)
+                y = DiffFusion.func_y(model.hjm_model, t)
+                x = sim.X[1:3,:,k]
+                one = mean(exp.(H'*(x .+ 0.5*y*(I - H))))
+                # display(one - 1.0)
+                @test isapprox(one, 1.0, atol=5.0e-3)
+            end
+        end
+    end
+
+    @testset "Simple simulation (full correlation)." begin
+        model = DiffFusion.markov_future_model("NIK",delta,chi,sigma_f,ch,nothing)
+        times = 0.0:2.0:10.0
+        n_paths = 2^10
+        sobol = DiffFusion.sobol_brownian_increments
+        sim = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false, brownian_increments=sobol)
+        @test size(sim.X) == (3,1024,6)
+        # martingale test for Future price
+        dt_ = [ 0.0, 1.0, 2.0, 5.0, 10.0 ]
+        for (k, t) in enumerate(sim.times)
+            for dt in dt_
+                H = DiffFusion.H_hjm(model, t, t+dt)
+                I = ones(3)
+                y = DiffFusion.func_y(model.hjm_model, t)
+                x = sim.X[1:3,:,k]
+                one = mean(exp.(H'*(x .+ 0.5*y*(I - H))))
+                # display(one - 1.0)
+                @test isapprox(one, 1.0, atol=4.9e-3)
+            end
+        end
+    end
+
+    @testset "Simple simulation (with quanto)." begin
+        asset_model = DiffFusion.lognormal_asset_model("EUR-USD", sigma_fx, ch, nothing)
+        markv_model = DiffFusion.markov_future_model("NIK",delta,chi,sigma_f,ch,asset_model)
+        model = DiffFusion.simple_model("Std", [markv_model, asset_model])
+        times = 0.0:2.0:10.0
+        n_paths = 2^10
+        sobol = DiffFusion.sobol_brownian_increments
+        sim = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false, brownian_increments=sobol)
+        @test size(sim.X) == (4,1024,6)
+        # martingale test for Future price
+        dt_ = [ 0.0, 1.0, 2.0, 5.0, 10.0 ]
+        for (k, t) in enumerate(sim.times)
+            for dt in dt_
+                H = DiffFusion.H_hjm(markv_model, t, t+dt)
+                I = ones(3)
+                y = DiffFusion.func_y(markv_model.hjm_model, t)
+                x = sim.X[1:3,:,k]
+                fx = sim.X[4:4,:,k]
+                one = mean(exp.(H'*(x .+ 0.5*y*(I - H)) + fx))
+                # display(one - 1.0)
+                @test isapprox(one, 1.0, atol=3.6e-3)
+            end
+        end
+    end
+
+end

--- a/test/unittests/simulations/simulations.jl
+++ b/test/unittests/simulations/simulations.jl
@@ -6,6 +6,7 @@ using Test
     # Add tests here.
     include("asset_model.jl")
     include("gaussain_hjm_model.jl")
+    include("markov_future_model.jl")
     include("simple_models.jl")
 
 end


### PR DESCRIPTION
This PR adds a Markov Future price model. The model is based on the multi-factor HJM model used for rates. 