### PR TITLE
Add Monte-Carlo Path and methods

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -9,6 +9,7 @@ using QuadGK
 using Sobol
 using SparseArrays
 
+import Base.length
 
 """
 A type alias for variables representing time.
@@ -35,10 +36,13 @@ include("models/rates/SeparableHjmModel.jl")
 include("models/rates/GaussianHjmModel.jl")
 include("models/futures/MarkovFutureModels.jl")
 
-include("paths/Context.jl")
-
 include("simulations/RandomNumbers.jl")
 include("simulations/Simulation.jl")
+
+include("paths/AbstractPath.jl")
+include("paths/Context.jl")
+include("paths/Path.jl")
+include("paths/PathMethods.jl")
 
 include("utils/Integrations.jl")
 include("utils/InterpolationMethods.jl")

--- a/src/paths/AbstractPath.jl
+++ b/src/paths/AbstractPath.jl
@@ -1,0 +1,240 @@
+
+"""
+    abstract type AbstractPath end
+
+An AbstractPath specifies the interface for path implementations.
+
+This aims at providing the flexibility to add other types of paths in
+the future.
+"""
+abstract type AbstractPath end
+
+"""
+    length(p::AbstractPath)
+
+Return the number of realisations represented by the AbstractPath
+object.
+
+We assume that model functions applied to an AbstractPath return a
+vector of length(p) where p is the number realisations.
+"""
+function length(p::AbstractPath)
+    error("AbstractPath needs to implement length method.")
+end
+
+"""
+    numeraire(p::AbstractPath, t::ModelTime, curve_key::String)
+
+Calculate the numeraire in the domestic currency.
+
+We allow for curve-specific numeraire calculation e.g. to allow
+for trade-specific discounting in AMC valuation.
+"""
+function numeraire(p::AbstractPath, t::ModelTime, curve_key::String)
+    error("AbstractPath needs to implement numeraire method.")
+end
+
+
+"""
+    bank_account(p::AbstractPath, t::ModelTime, key::String)
+
+Calculate a continuous compounded bank account value.
+"""
+function bank_account(p::AbstractPath, t::ModelTime, key::String)
+    error("AbstractPath needs to implement bank_account method.")
+end
+
+
+"""
+    zero_bond(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+
+Calculate a zero coupon bond price.
+"""
+function zero_bond(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+    error("AbstractPath needs to implement zero_bond method.")
+end
+
+
+"""
+    asset(p::AbstractPath, t::ModelTime, key::String)
+
+Calculate asset price.
+"""
+function asset(p::AbstractPath, t::ModelTime, key::String)
+    error("AbstractPath needs to implement asset method.")
+end
+
+
+"""
+    forward_asset(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+
+Calculate forward asset price as expectation in T-forward measure.
+"""
+function forward_asset(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+    error("AbstractPath needs to implement forward_asset method.")
+end
+
+
+"""
+    fixing(p::AbstractPath, t::ModelTime, key::String)
+
+Return a fixing from a term structure.
+
+This is used to handle fixings for indices etc.
+"""
+function fixing(p::AbstractPath, t::ModelTime, key::String)
+    error("AbstractPath needs to implement fixing method.")
+end
+
+"""
+    asset_convexity_adjustment(
+        p::AbstractPath,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        key::String
+        )
+
+Return the convexity adjustment for a YoY asset payoff.
+"""
+function asset_convexity_adjustment(
+    p::AbstractPath,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    key::String
+    )
+    error("AbstractPath needs to implement asset_convexity_adjustment method.")
+end
+
+"""
+    forward_index(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+
+Expectation E_t^T[S_T] of a tradeable asset.
+"""
+function forward_index(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+    error("AbstractPath needs to implement forward_index method.")
+end
+
+"""
+    index_convexity_adjustment(
+        p::AbstractPath,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        key::String
+        )
+
+Return the convexity adjustment for a YoY index payoff.
+"""
+function index_convexity_adjustment(
+    p::AbstractPath,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    key::String
+    )
+    error("AbstractPath needs to implement index_convexity_adjustment method.")
+end
+
+
+"""
+    future_index(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+
+Expectation E_t^Q[F(T,T)] of a Future index/price.
+"""
+function future_index(p::AbstractPath, t::ModelTime, T::ModelTime, key::String)
+    error("AbstractPath needs to implement future_index method.")
+end
+
+
+"""
+    swap_rate_variance(
+        p::AbstractPath,
+        t::ModelTime,
+        T::ModelTime,
+        swap_times::AbstractVector,
+        yf_weights::AbstractVector,
+        key::String,
+        )
+
+Calculate the normal model variance of a swap rate via Gaussian
+swap rate approximation.
+"""
+function swap_rate_variance(
+    p::AbstractPath,
+    t::ModelTime,
+    T::ModelTime,
+    swap_times::AbstractVector,
+    yf_weights::AbstractVector,
+    key::String,
+    )
+    error("AbstractPath needs to implement swap_rate_variance method.")
+end
+
+
+"""
+    forward_rate_variance(
+    p::AbstractPath,
+    t::ModelTime,
+    T::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    key::String,
+    )
+
+Calculate the lognormal model variance of a forward looking or
+backward looking forward rate.
+"""
+function forward_rate_variance(
+    p::AbstractPath,
+    t::ModelTime,
+    T::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    key::String,
+    )
+    error("AbstractPath needs to implement forward_rate_variance method.")
+end
+
+
+"""
+    asset_variance(
+        p::AbstractPath,
+        t::ModelTime,
+        T::ModelTime,
+        key::String,
+        )
+
+Calculate the lognormal model variance of an asset spot price
+over the time period [t,T].
+"""
+function asset_variance(
+    p::AbstractPath,
+    t::ModelTime,
+    T::ModelTime,
+    key::String,
+    )
+    error("AbstractPath needs to implement asset_variance method.")
+end
+
+
+"""
+    @enum(
+        PathInterpolation,
+        NoPathInterpolation,
+        LinearPathInterpolation,
+    )
+
+PathInterpolation encodes how simulated states can be interpolates.
+"""
+@enum(
+    PathInterpolation,
+    NoPathInterpolation,
+    LinearPathInterpolation,
+)
+

--- a/src/paths/Path.jl
+++ b/src/paths/Path.jl
@@ -1,0 +1,188 @@
+
+"""
+    struct Path <: AbstractPath
+        sim::Simulation
+        ts_dict::Dict{String,<:Termstructure}
+        state_alias_dict::Dict{String,Int}
+        context::Context
+        interpolation::PathInterpolation
+    end
+
+A Path combines a model, simulated model states and term structures. The interface
+to market references is established by a valuation context.
+
+Paths are used by payoffs to calculate simulated zero bonds, asset prices
+and further building blocks of financial instrument payoffs.
+"""
+struct Path <: AbstractPath
+    sim::Simulation
+    ts_dict::Dict{String,<:Termstructure}
+    state_alias_dict::Dict{String,Int}
+    context::Context
+    interpolation::PathInterpolation
+end
+
+"""
+    _check_path_setup(
+        sim::Simulation,
+        ts_dict::Dict{String,Termstructure},
+        cxt::Context,
+        )
+
+Check for consistent path inputs.
+
+We define an extra function in order to avoid chain rule issues with
+automatic differentiation.
+"""
+function _check_path_setup(
+    sim::Simulation,
+    ts_dict::Dict{String,<:Termstructure},
+    cxt::Context,
+    )
+    # all referenced models need to be available
+    @assert isnothing(cxt.numeraire.model_alias) || cxt.numeraire.model_alias in model_alias(sim.model)
+    for entry in values(cxt.rates)
+        @assert isnothing(entry.model_alias) || entry.model_alias in model_alias(sim.model)
+    end
+    for entry in values(cxt.assets)
+        @assert isnothing(entry.asset_model_alias) || entry.asset_model_alias in model_alias(sim.model)
+        @assert isnothing(entry.domestic_model_alias) || entry.domestic_model_alias in model_alias(sim.model)
+        @assert isnothing(entry.foreign_model_alias) || entry.foreign_model_alias in model_alias(sim.model)
+    end
+    # keys and value aliases must be consistent
+    for (key, ts) in ts_dict
+        @assert key == alias(ts)
+    end
+    # all referenced term structures need to be available
+    for alias in unique(values(cxt.numeraire.termstructure_dict))
+        @assert alias in keys(ts_dict)
+        @assert isa(ts_dict[alias], YieldTermstructure)
+    end
+    for entry in values(cxt.rates)
+        for alias in unique(values(entry.termstructure_dict))
+            @assert alias in keys(ts_dict)
+            @assert isa(ts_dict[alias], YieldTermstructure)
+        end
+    end
+    for entry in values(cxt.assets)
+        @assert entry.asset_spot_alias in keys(ts_dict)
+        @assert isa(ts_dict[entry.asset_spot_alias], ParameterTermstructure)
+        for alias in unique(values(entry.domestic_termstructure_dict))
+            @assert alias in keys(ts_dict)
+            @assert isa(ts_dict[alias], YieldTermstructure)
+        end
+        for alias in unique(values(entry.foreign_termstructure_dict))
+            @assert alias in keys(ts_dict)
+            @assert isa(ts_dict[alias], YieldTermstructure)
+        end
+    end
+    for entry in values(cxt.forward_indices)
+        @assert entry.forward_index_alias in keys(ts_dict)
+        @assert isa(ts_dict[entry.forward_index_alias], ParameterTermstructure)
+    end
+    for entry in values(cxt.future_indices)
+        @assert entry.future_index_alias in keys(ts_dict)
+        @assert isa(ts_dict[entry.future_index_alias], ParameterTermstructure)
+    end
+    for entry in values(cxt.fixings)
+        @assert entry.termstructure_alias in keys(ts_dict)
+        @assert isa(ts_dict[entry.termstructure_alias], ParameterTermstructure)
+    end
+end
+
+"""
+    path(
+        sim::Simulation,
+        ts_dict::Dict{String,<:Termstructure},
+        cxt::Context,
+        ip::PathInterpolation = NoPathInterpolation
+        )
+
+Create a Path object.
+"""
+function path(
+    sim::Simulation,
+    ts_dict::Dict{String,<:Termstructure},
+    cxt::Context,
+    ip::PathInterpolation = NoPathInterpolation
+    )
+    _check_path_setup(sim, ts_dict, cxt)
+    state_alias_dict = alias_dictionary(state_alias(sim.model))
+    return Path(sim, ts_dict, state_alias_dict, cxt, ip)
+end
+
+"""
+    _check_unique_ts(ts_alias::AbstractVector)
+
+Check for consistent term structure inputs to path.
+
+We define an extra function in order to avoid chain rule issues with
+automatic differentiation.
+"""
+function _check_unique_ts(ts_alias::AbstractVector)
+    @assert length(ts_alias) == length(unique(ts_alias))
+end
+
+"""
+    path(
+        sim::Simulation,
+        ts::Vector{Termstructure},
+        cxt::Context,
+        ip::PathInterpolation = NoPathInterpolation
+        )
+
+Create a Path object from a list of term structures.
+"""
+function path(
+    sim::Simulation,
+    ts::Vector{<:Termstructure},
+    cxt::Context,
+    ip::PathInterpolation = NoPathInterpolation
+    )
+    #
+    ts_alias = [ alias(ts_) for ts_ in ts ]
+    _check_unique_ts(ts_alias)
+    #
+    ts_dict = Dict{String,Termstructure}(((alias(ts_), ts_) for ts_ in ts))
+    return path(sim, ts_dict, cxt, ip)
+end
+
+"""
+    length(p::Path)
+
+Derive the number of realisations from the linked simulation.
+"""
+function length(p::Path)
+    return size(p.sim.X)[2]
+end
+
+"""
+    state_variable(sim::Simulation, t::ModelTime, ip::PathInterpolation)
+
+Derive a state variable for a given observation time.
+"""
+function state_variable(sim::Simulation, t::ModelTime, ip::PathInterpolation)
+    eps = 0.5 / 365  # we want to give a bit tolerance in avoiding interpolation
+    idx = searchsortedfirst(sim.times, t)
+    if idx <= length(sim.times) && t > sim.times[idx] - eps
+        return @view sim.X[:,:,idx]
+    end
+    if idx > 1 && t < sim.times[idx-1] + eps
+        return @view sim.X[:,:,idx-1]
+    end
+    # if we end up here we need some interpolation/extrapolation
+    @assert ip != NoPathInterpolation
+    # we assume constant extrapolation
+    if idx == 1
+        return @view sim.X[:,:,idx]
+    end
+    if idx > length(sim.times)
+        return @view sim.X[:,:,idx-1]
+    end
+    # now we have 1 < idx <= length(sim.times)
+    if ip == LinearPathInterpolation
+        rho = (t - sim.times[idx-1]) / (sim.times[idx] - sim.times[idx-1])
+        return rho * @view(sim.X[:,:,idx]) + (1.0-rho) * @view(sim.X[:,:,idx-1])
+    end
+    error("Unknown PathInterpolation.")
+end

--- a/src/paths/PathMethods.jl
+++ b/src/paths/PathMethods.jl
@@ -1,0 +1,297 @@
+
+"""
+Implement AbstractPath interface functions.
+
+These methods implement the reconstruction of financial quantities from
+modelled state variables and model functions.
+"""
+
+
+"""
+    discount(
+        t::ModelTime,
+        ts_dict::Dict{String,Termstructure},
+        first_alias::String,
+        second_alias::Union{String,Nothing} = nothing,
+        operation::Union{String,Nothing} = nothing,
+        )
+
+Derive the discount factor for one or two of curve alias and a curve operation.
+"""
+function discount(
+    t::ModelTime,
+    ts_dict::Dict{String,Termstructure},
+    first_alias::String,
+    second_alias::Union{String,Nothing} = nothing,
+    operation::Union{String,Nothing} = nothing,
+    )
+    ts1 = ts_dict[first_alias]
+    @assert isa(ts1, YieldTermstructure)
+    df1 = discount(ts1, t)
+    if !isnothing(second_alias)
+        @assert operation in ("+", "-")
+        ts2 = ts_dict[second_alias]
+        @assert isa(ts2, YieldTermstructure)
+        df2 = discount(ts2, t)
+        if operation == "+"
+            df1 *= df2
+        end 
+        if operation == "-"
+            df1 /= df2
+        end
+    end
+    return df1
+end
+
+
+"""
+    numeraire(p::Path, t::ModelTime, curve_key::String)
+
+Calculate the numeraire in the domestic currency.
+
+We allow for curve-specific numeraire calculation e.g. to allow
+for trade-specific discounting in AMC valuation.
+"""
+function numeraire(p::Path, t::ModelTime, curve_key::String)
+    key = _split_key_identifyer * curve_key  # allow for context key parsing and ensure normalisation
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    entry = p.context.numeraire
+    ts_alias_1 = entry.termstructure_dict[ts_key_1]
+    df = discount(t, p.ts_dict, ts_alias_1)
+    if isnothing(p.context.numeraire.model_alias)
+        return (1.0/df) * ones(size(p.sim.X)[2]) 
+    end
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    s = log_bank_account(p.sim.model, p.context.numeraire.model_alias, t, SX)
+    return (1.0/df) * exp.(s)
+end
+
+
+"""
+    bank_account(p::Path, t::ModelTime, key::String)
+
+Calculate a continuous compounded bank account value.
+"""
+function bank_account(p::Path, t::ModelTime, key::String)
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    entry = p.context.rates[context_key]
+    ts_alias_1 = entry.termstructure_dict[ts_key_1]
+    if ts_key_2 == _empty_context_key || op == _empty_context_key
+        # This is some business logic that overlaps with context_keys(...).
+        # However, the logic is different e.g. for assets. So it makes
+        # sense to leave it here.
+        ts_alias_2 = nothing
+    else
+        ts_alias_2 = entry.termstructure_dict[ts_key_2]
+    end
+    df = discount(t, p.ts_dict, ts_alias_1, ts_alias_2, op)
+    if isnothing(entry.model_alias)
+        return (1.0/df) * ones(size(p.sim.X)[2]) 
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    s = log_bank_account(p.sim.model, entry.model_alias, t, SX)
+    return (1.0/df) * exp.(s)
+end
+
+
+"""
+    zero_bond(p::Path, t::ModelTime, T::ModelTime, key::String)
+
+Calculate a zero coupon bond price.
+"""
+function zero_bond(p::Path, t::ModelTime, T::ModelTime, key::String)
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    entry = p.context.rates[context_key]
+    ts_alias_1 = entry.termstructure_dict[ts_key_1]
+    if ts_key_2 == _empty_context_key || op == _empty_context_key
+        # This is some business logic that overlaps with context_keys(...).
+        # However, the logic is different e.g. for assets. So it makes
+        # sense to leave it here.
+        ts_alias_2 = nothing
+    else
+        ts_alias_2 = entry.termstructure_dict[ts_key_2]
+    end
+    df1 = discount(t, p.ts_dict, ts_alias_1, ts_alias_2, op)
+    df2 = discount(T, p.ts_dict, ts_alias_1, ts_alias_2, op)
+    if isnothing(entry.model_alias)
+        return (df2/df1) * ones(size(p.sim.X)[2])
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    s = log_zero_bond(p.sim.model, entry.model_alias, t, T, SX)
+    return (df2/df1) * exp.(-s)
+end
+
+
+"""
+    asset(p::Path, t::ModelTime, key::String)
+
+Calculate asset price.
+"""
+function asset(p::Path, t::ModelTime, key::String)
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key, "-")
+    entry = p.context.assets[context_key]
+    #
+    spot_alias = entry.asset_spot_alias
+    spot = p.ts_dict[spot_alias](t, TermstructureScalar)
+    #
+    ts_alias_1 = entry.foreign_termstructure_dict[ts_key_1]
+    ts_alias_2 = entry.domestic_termstructure_dict[ts_key_2]
+    df = discount(t, p.ts_dict, ts_alias_1, ts_alias_2, "-")  # double-check (de-)numerator
+    #
+    if isnothing(entry.asset_model_alias) &&
+        isnothing(entry.foreign_model_alias) &&
+        isnothing(entry.domestic_model_alias)
+        # we can take a short-cut for fully deterministic models
+        return (spot*df) * ones(size(p.sim.X)[2])
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    y = zeros(size(p.sim.X)[2])
+    if !isnothing(entry.asset_model_alias)
+        y += log_asset(p.sim.model, entry.asset_model_alias, t, SX)
+    end
+    if !isnothing(entry.domestic_model_alias)
+        y += log_bank_account(p.sim.model, entry.domestic_model_alias, t, SX)
+    end
+    if !isnothing(entry.foreign_model_alias)
+        y -= log_bank_account(p.sim.model, entry.foreign_model_alias, t, SX)
+    end
+    return (spot*df) * exp.(y)
+end
+
+
+"""
+    forward_asset(p::Path, t::ModelTime, T::ModelTime, key::String)
+
+Calculate forward asset price as expectation in T-forward measure, conditional on time-t.
+"""
+function forward_asset(p::Path, t::ModelTime, T::ModelTime, key::String)
+    @assert t <= T
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key, "-")
+    entry = p.context.assets[context_key]
+    #
+    spot_alias = entry.asset_spot_alias
+    spot = p.ts_dict[spot_alias](T, TermstructureScalar)  # capture any discrete jumps until T
+    #
+    ts_alias_1 = entry.foreign_termstructure_dict[ts_key_1]
+    ts_alias_2 = entry.domestic_termstructure_dict[ts_key_2]
+    df = discount(T, p.ts_dict, ts_alias_1, ts_alias_2, "-")  # capture continuous dividends/discounting until T
+    #
+    if isnothing(entry.asset_model_alias) &&
+        isnothing(entry.foreign_model_alias) &&
+        isnothing(entry.domestic_model_alias)
+        # we can take a short-cut for fully deterministic models
+        return (spot*df) * ones(size(p.sim.X)[2])
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    y = zeros(size(p.sim.X)[2])
+    if !isnothing(entry.asset_model_alias)
+        y += log_asset(p.sim.model, entry.asset_model_alias, t, SX)
+    end
+    if !isnothing(entry.domestic_model_alias)
+        y += log_bank_account(p.sim.model, entry.domestic_model_alias, t, SX)
+        y += log_zero_bond(p.sim.model, entry.domestic_model_alias, t, T, SX)
+    end
+    if !isnothing(entry.foreign_model_alias)
+        y -= log_bank_account(p.sim.model, entry.foreign_model_alias, t, SX)
+        y -= log_zero_bond(p.sim.model, entry.foreign_model_alias, t, T, SX)
+    end
+    return (spot*df) * exp.(y)
+end
+
+
+"""
+    fixing(p::Path, t::ModelTime, key::String)
+
+Return a fixing from a term structure.
+"""
+function fixing(p::Path, t::ModelTime, key::String)
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    context_key = _join_context_keys(context_key, ts_key_1, ts_key_2, op)  # workaround
+    entry = p.context.fixings[context_key]
+    #
+    ts_alias = entry.termstructure_alias
+    fixing = p.ts_dict[ts_alias](t, TermstructureScalar)
+    return fixing * ones(length(p))
+end
+
+
+
+"""
+    forward_index(p::Path, t::ModelTime, T::ModelTime, key::String)
+
+Expectation E_t^T[S_T] of a tradeable asset.
+"""
+function forward_index(p::Path, t::ModelTime, T::ModelTime, key::String)
+    @assert t <= T
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key, "-")
+    entry = p.context.forward_indices[context_key]
+    #
+    forward_index_alias = entry.forward_index_alias
+    forward_index = p.ts_dict[forward_index_alias](T, TermstructureScalar)
+    #
+    if isnothing(entry.asset_model_alias) &&
+        isnothing(entry.foreign_model_alias) &&
+        isnothing(entry.domestic_model_alias)
+        # we can take a short-cut for fully deterministic models
+        return forward_index * ones(size(p.sim.X)[2])
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    y = zeros(size(p.sim.X)[2])
+    if !isnothing(entry.asset_model_alias)
+        y += log_asset(p.sim.model, entry.asset_model_alias, t, SX)
+    end
+    if !isnothing(entry.domestic_model_alias)
+        y += log_bank_account(p.sim.model, entry.domestic_model_alias, t, SX)
+        if t < T
+            y += log_zero_bond(p.sim.model, entry.domestic_model_alias, t, T, SX)
+        end
+    end
+    if !isnothing(entry.foreign_model_alias)
+        y -= log_bank_account(p.sim.model, entry.foreign_model_alias, t, SX)
+        if t < T
+            y -= log_zero_bond(p.sim.model, entry.foreign_model_alias, t, T, SX)
+        end
+    end
+    return forward_index * exp.(y)
+end
+
+
+"""
+    future_index(p::Path, t::ModelTime, T::ModelTime, key::String)
+
+Expectation E_t^Q[F(T,T)] of a Future index/price.
+"""
+function future_index(p::Path, t::ModelTime, T::ModelTime, key::String)
+    @assert t <= T
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key, "-")
+    entry = p.context.future_indices[context_key]
+    #
+    future_index_alias = entry.future_index_alias
+    future_index = p.ts_dict[future_index_alias](T, TermstructureScalar)
+    #
+    if isnothing(entry.future_model_alias)
+        # we can take a short-cut for fully deterministic models
+        return future_index * ones(size(p.sim.X)[2])
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    y = log_future(p.sim.model, entry.future_model_alias, t, T, SX)
+    return future_index * exp.(y)
+end
+

--- a/test/unittests/paths/path.jl
+++ b/test/unittests/paths/path.jl
@@ -1,0 +1,335 @@
+
+using DiffFusion
+using Test
+
+@testset "AbstractPath" begin
+
+    @testset "AbstractPath setup" begin
+        struct NoPath <: DiffFusion.AbstractPath end
+        @test_throws ErrorException DiffFusion.numeraire(NoPath(), 5.0, "Std")
+        @test_throws ErrorException DiffFusion.bank_account(NoPath(), 5.0, "Std")
+        @test_throws ErrorException DiffFusion.zero_bond(NoPath(), 5.0, 10.0, "Std")
+        @test_throws ErrorException DiffFusion.asset(NoPath(), 5.0, "Std")
+        @test_throws ErrorException DiffFusion.forward_asset(NoPath(), 5.0, 10.0, "Std")
+        @test_throws ErrorException DiffFusion.forward_index(NoPath(), 5.0, 10.0, "Std")
+        @test_throws ErrorException DiffFusion.future_index(NoPath(), 5.0, 10.0, "Std")
+        @test_throws ErrorException DiffFusion.fixing(NoPath(), 5.0, "Std")
+        @test_throws ErrorException DiffFusion.length(NoPath())
+    end
+
+end
+
+@testset "Monte Carlo paths." begin
+    
+    _empty_key = DiffFusion._empty_context_key
+
+    # hybrid model
+
+    ch = DiffFusion.correlation_holder("Std")
+
+    sigma_fx = DiffFusion.flat_volatility("EUR-USD", 0.15)
+    fx_model = DiffFusion.lognormal_asset_model("EUR-USD", sigma_fx, ch, nothing)
+
+    sigma_fx = DiffFusion.flat_volatility("SXE50", 0.10)
+    eq_model = DiffFusion.lognormal_asset_model("SXE50-EUR", sigma_fx, ch, fx_model)
+
+    delta_dom = DiffFusion.flat_parameter([ 1., 7., 15. ])
+    chi_dom = DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ])
+    times_dom =  [ 0. ]
+    values_dom = [ 50. 60. 70.]' * 1.0e-4
+    sigma_f_dom = DiffFusion.backward_flat_volatility("USD",times_dom,values_dom)
+    hjm_model_dom = DiffFusion.gaussian_hjm_model("USD",delta_dom,chi_dom,sigma_f_dom,ch,nothing)
+
+    delta_for = DiffFusion.flat_parameter([ 1., 10. ])
+    chi_for = DiffFusion.flat_parameter([ 0.01, 0.15 ])
+    times_for =  [ 0. ]
+    values_for = [ 80. 90. ]' * 1.0e-4
+    sigma_f_for = DiffFusion.backward_flat_volatility("EUR",times_for,values_for)
+    hjm_model_for = DiffFusion.gaussian_hjm_model("EUR",delta_for,chi_for,sigma_f_for,ch,fx_model)
+
+    delta_nik = DiffFusion.flat_parameter(1.0)
+    chi_nik = DiffFusion.flat_parameter(0.05)
+    sigma_nik = DiffFusion.flat_volatility("NIK", 0.10)
+    mkv_model = DiffFusion.markov_future_model("NIK", delta_nik, chi_nik, sigma_nik, nothing, nothing)
+
+    m = DiffFusion.simple_model("Std", [ hjm_model_dom, fx_model, hjm_model_for, eq_model, mkv_model ])
+
+    # artificial simulation
+
+    times = [ 0.0, 1.0, 2.0, 4.0, 8.0, 16. ]
+    n_paths = 5
+    X = ones(length(DiffFusion.state_alias(m)), n_paths, length(times))
+    X[:,:,1] = zeros(length(DiffFusion.state_alias(m)), n_paths)
+    X[:,:,5] = 2.0 * ones(length(DiffFusion.state_alias(m)), n_paths)
+    sim = DiffFusion.Simulation(m, times, X)
+
+    # valuation context with deterministic dividend yield
+
+    context = DiffFusion.Context("Std",
+        DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+        Dict{String, DiffFusion.RatesEntry}([
+            ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD", "OIS" => "USD", "NO" => "ZERO"))),
+            ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR", "NO" => "ZERO"))),
+            ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+        ]),
+        Dict{String, DiffFusion.AssetEntry}([
+            ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+            ("SXE50",   DiffFusion.AssetEntry("SXE50", "SXE50-EUR", "EUR", nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ("HICP", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "ZERO"), Dict(_empty_key => "ZERO"))),
+        ]),
+        Dict{String, DiffFusion.ForwardIndexEntry}([
+            ("HICP", DiffFusion.ForwardIndexEntry("EUR-USD-FWD", "EUR-USD", "USD", "EUR", "EUR-USD-FWD")),
+        ]),
+        Dict{String, DiffFusion.FutureIndexEntry}([
+            ("NIK", DiffFusion.FutureIndexEntry("NIK", "NIK", "NIK-FUT")),
+        ]),
+        Dict{String, DiffFusion.FixingEntry}([
+            ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
+        ]),
+    )
+
+    # term structures
+    ts = [
+        DiffFusion.flat_forward("USD", 0.03),
+        DiffFusion.flat_forward("EUR", 0.02),
+        DiffFusion.flat_forward("SXE50", 0.01),
+        DiffFusion.flat_parameter("EUR-USD", 1.25),
+        DiffFusion.flat_parameter("EUR-USD-FWD", 1.25),
+        DiffFusion.flat_parameter("SXE50-EUR", 3750.00),
+        DiffFusion.flat_forward("ZERO", 0.00),
+        DiffFusion.flat_parameter("NIK-FUT", 23776.50),
+        DiffFusion.flat_parameter("USD-SOFR-Fixings", 0.0123),
+    ]
+
+    @testset "Path setup." begin
+        p = DiffFusion.path(sim, ts, context)
+        @test p.interpolation == DiffFusion.NoPathInterpolation
+        @test length(p) == 5
+        # missing rates model
+        wrong_cxt = DiffFusion.Context("Std",
+            DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+            Dict{String, DiffFusion.RatesEntry}([
+                ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD"))),
+                ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR"))),
+                ("SXE50", DiffFusion.RatesEntry("SXE50", "SXE50", Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.AssetEntry}([
+                ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+                ("SXE50",   DiffFusion.AssetEntry("SXE50", "SXE50-EUR", "EUR", nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.ForwardIndexEntry}(),
+            Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.FixingEntry}(),
+        )
+        @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
+        # missing asset model
+        wrong_cxt = DiffFusion.Context("Std",
+            DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+            Dict{String, DiffFusion.RatesEntry}([
+                ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD"))),
+                ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR"))),
+                ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.AssetEntry}([
+                ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+                ("SXE50",   DiffFusion.AssetEntry("SXE50", "SXE50", "EUR", nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.ForwardIndexEntry}(),
+            Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.FixingEntry}(),
+        )
+        @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
+        # missing foreign rates model
+        wrong_cxt = DiffFusion.Context("Std",
+            DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+            Dict{String, DiffFusion.RatesEntry}([
+                ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD"))),
+                ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR"))),
+                ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.AssetEntry}([
+                ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+                ("SXE50",   DiffFusion.AssetEntry("SXE50", "SXE50-EUR", "EUR", "SXE50", "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.ForwardIndexEntry}(),
+            Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.FixingEntry}(),
+        )
+        @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
+        # missing term structure
+        wrong_cxt = DiffFusion.Context("Std",
+            DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+            Dict{String, DiffFusion.RatesEntry}([
+                ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD"))),
+                ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR"))),
+                ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.AssetEntry}([
+                ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+                ("SXE50",   DiffFusion.AssetEntry("SXE50", "SXE50-EUR", "EUR", nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.ForwardIndexEntry}(),
+            Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.FixingEntry}([
+                ("USD-SOFR", DiffFusion.FixingEntry("USD-SOFR", "USD-SOFR-Fixings")),
+            ]),
+        )
+        DiffFusion.path(sim, ts, wrong_cxt)
+        @test_throws AssertionError DiffFusion.path(sim, ts[2:end], wrong_cxt)
+        @test_throws AssertionError DiffFusion.path(sim, ts[1:end-1], wrong_cxt)
+    end
+
+    @testset "State variable calculation" begin
+        #
+        @test DiffFusion.state_variable(sim, 0.0, DiffFusion.NoPathInterpolation) == zeros(10, 5)
+        @test DiffFusion.state_variable(sim, 1.0, DiffFusion.NoPathInterpolation) == ones(10, 5)
+        @test DiffFusion.state_variable(sim, 8.0, DiffFusion.NoPathInterpolation) == 2.0 * ones(10, 5)
+        #
+        @test DiffFusion.state_variable(sim, 8.0 - 0.4/365, DiffFusion.NoPathInterpolation) == 2.0 * ones(10, 5)
+        @test DiffFusion.state_variable(sim, 8.0 + 0.4/365, DiffFusion.NoPathInterpolation) == 2.0 * ones(10, 5)
+        @test DiffFusion.state_variable(sim, 0.0 - 0.4/365, DiffFusion.NoPathInterpolation) == zeros(10, 5)
+        @test DiffFusion.state_variable(sim, 16.0 + 0.4/365, DiffFusion.NoPathInterpolation) == ones(10, 5)
+        #
+        @test_throws AssertionError DiffFusion.state_variable(sim, -0.5, DiffFusion.NoPathInterpolation)
+        @test_throws AssertionError DiffFusion.state_variable(sim,  1.5, DiffFusion.NoPathInterpolation)
+        @test_throws AssertionError DiffFusion.state_variable(sim, 16.5, DiffFusion.NoPathInterpolation)
+        #
+        @test DiffFusion.state_variable(sim, 0.0, DiffFusion.LinearPathInterpolation) == zeros(10, 5)
+        @test DiffFusion.state_variable(sim, 1.0, DiffFusion.LinearPathInterpolation) == ones(10, 5)
+        @test DiffFusion.state_variable(sim, 8.0, DiffFusion.LinearPathInterpolation) == 2.0 * ones(10, 5)
+        #
+        @test DiffFusion.state_variable(sim, 8.0 - 0.4/365, DiffFusion.LinearPathInterpolation) == 2.0 * ones(10, 5)
+        @test DiffFusion.state_variable(sim, 8.0 + 0.4/365, DiffFusion.LinearPathInterpolation) == 2.0 * ones(10, 5)
+        @test DiffFusion.state_variable(sim, 0.0 - 0.4/365, DiffFusion.LinearPathInterpolation) == zeros(10, 5)
+        @test DiffFusion.state_variable(sim, 16.0 + 0.4/365, DiffFusion.LinearPathInterpolation) == ones(10, 5)
+        #
+        @test DiffFusion.state_variable(sim, -0.5, DiffFusion.LinearPathInterpolation) == zeros(10, 5)
+        @test DiffFusion.state_variable(sim,  0.5, DiffFusion.LinearPathInterpolation) == 0.5 * ones(10, 5)
+        @test DiffFusion.state_variable(sim,  0.5, DiffFusion.LinearPathInterpolation) == 0.5 * ones(10, 5)
+        @test DiffFusion.state_variable(sim,  5.0, DiffFusion.LinearPathInterpolation) == 1.25 * ones(10, 5)
+        @test DiffFusion.state_variable(sim, 16.5, DiffFusion.LinearPathInterpolation) == ones(10, 5)
+    end
+
+    @testset "Alias-based discount factors." begin
+        p = DiffFusion.path(sim, ts, context)
+        t = 2.0
+        @test DiffFusion.discount(t, p.ts_dict, "USD") == exp(-0.03 * t)
+        @test DiffFusion.discount(t, p.ts_dict, "EUR") == exp(-0.02 * t)
+        @test DiffFusion.discount(t, p.ts_dict, "SXE50") == exp(-0.01 * t)
+        @test isapprox(DiffFusion.discount(t, p.ts_dict, "EUR", "USD",   "+"), exp(-0.05 * t), atol=1.0e-15)
+        @test isapprox(DiffFusion.discount(t, p.ts_dict, "USD", "SXE50", "+"), exp(-0.04 * t), atol=1.0e-15)
+        @test isapprox(DiffFusion.discount(t, p.ts_dict, "USD", "EUR",   "-"), exp(-0.01 * t), atol=1.0e-15)
+        @test isapprox(DiffFusion.discount(t, p.ts_dict, "SXE50", "USD", "-"), exp(+0.02 * t), atol=1.0e-15)
+        #
+        @test DiffFusion.discount(t, p.ts_dict, "EUR", nothing, "+") == exp(-0.02 * t)
+        @test_throws AssertionError DiffFusion.discount(t, p.ts_dict, "EUR", "USD", "*")
+        @test_throws AssertionError DiffFusion.discount(t, p.ts_dict, "EUR", "USD", nothing)
+    end
+
+    @testset "Stochastic model functions." begin
+        p = DiffFusion.path(sim, ts, context)
+        t = 2.0
+        @test isapprox(DiffFusion.numeraire(p, t, ""), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
+        #
+        @test isapprox(DiffFusion.bank_account(p, t, "USD"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "EUR"), exp(1.0 + 0.02*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "SXE50"), exp(0.01*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "USD:NO"), exp(1.0 + 0.00*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "USD:OIS"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "USD:NO-OIS"), exp(1.0 - 0.03*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "USD:OIS+OIS"), exp(1.0 + 0.06*t) * ones(5), atol=5.0e-15)
+        #
+        @test_throws KeyError DiffFusion.bank_account(p, t, "GBP")
+        @test_throws KeyError DiffFusion.bank_account(p, t, "USD:LIB")
+        @test_throws KeyError DiffFusion.bank_account(p, t, "USD:OIS-LIB3M")
+        #
+        T = 5.0
+        zb0 = DiffFusion.zero_bond(p, t, T, "USD:NO")
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "USD"), zb0 * exp(-0.03*(T-t)), atol=5.0e-15)
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "USD:OIS-OIS"), zb0, atol=5.0e-15)
+        zb0 = DiffFusion.zero_bond(p, t, T, "EUR:NO")
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "EUR"), zb0 * exp(-0.02*(T-t)), atol=5.0e-15)
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "SXE50"), ones(5) * exp(-0.01*(T-t)), atol=5.0e-15)
+        #
+        @test_throws KeyError DiffFusion.zero_bond(p, t, T, "GBP")
+        @test_throws KeyError DiffFusion.zero_bond(p, t, T, "USD:LIB")
+        @test_throws KeyError DiffFusion.zero_bond(p, t, T, "USD:OIS-LIB3M")
+        @test_throws KeyError DiffFusion.zero_bond(p, t, T, "SXE50:OIS")
+        #
+        X = zeros(length(DiffFusion.state_alias(m)), n_paths, length(times))
+        sim = DiffFusion.Simulation(m, times, X)  # simplify calculations
+        p = DiffFusion.path(sim, ts, context)
+        @test isapprox(DiffFusion.asset(p, t, "EUR-USD"), ones(5) * 1.25 * exp(0.01*t), atol=5.0e-15)
+        @test isapprox(DiffFusion.asset(p, t, "SXE50"), ones(5) * 3750.00 * exp(0.01*t), atol=5.0e-15)
+        #
+        S_t = DiffFusion.asset(p, t, "EUR-USD")
+        P_d = DiffFusion.zero_bond(p, t, T, "USD")
+        P_f = DiffFusion.zero_bond(p, t, T, "EUR")
+        @test isapprox(DiffFusion.forward_asset(p, t, T, "EUR-USD"), S_t .* P_f ./ P_d, atol=5.0e-15)
+        #
+        S_t = DiffFusion.asset(p, t, "SXE50")
+        P_d = DiffFusion.zero_bond(p, t, T, "EUR")
+        P_f = DiffFusion.zero_bond(p, t, T, "SXE50")
+        @test isapprox(DiffFusion.forward_asset(p, t, T, "SXE50"), S_t .* P_f ./ P_d, atol=5.0e-15)
+        #
+        @test DiffFusion.fixing(p, -1.0, "SOFR") == 0.0123 * ones(5)
+        @test DiffFusion.fixing(p,  0.0, "SOFR") == 0.0123 * ones(5)
+        @test DiffFusion.fixing(p,  0.5, "SOFR") == 0.0123 * ones(5)
+        #
+        fwd_index_1 = DiffFusion.forward_index(p, 4.0, 5.0, "HICP")
+        fwd_index_2 = DiffFusion.asset(p, 4.0, "HICP") .* DiffFusion.zero_bond(p, 4.0, 5.0, "EUR:NO") ./ DiffFusion.zero_bond(p, 4.0, 5.0, "USD:NO")
+        @test isapprox(fwd_index_1, fwd_index_2, atol=5.0e-15)
+        #
+        @test DiffFusion.future_index(p, 4.0, 4.0, "NIK") == 23776.5 * ones(5)
+        fut_idx = DiffFusion.future_index(p, 4.0, 8.0, "NIK")
+        @test isapprox(fut_idx, 23840.87131543661 * ones(5), atol=1.0e-15)
+        #
+    end
+
+    @testset "Deterministic modelling." begin
+        det_context = DiffFusion.Context("Std",
+            DiffFusion.NumeraireEntry("USD", nothing, Dict(_empty_key => "USD")),
+            Dict{String, DiffFusion.RatesEntry}([
+                ("USD",   DiffFusion.RatesEntry("USD", nothing, Dict(_empty_key => "USD"))),
+                ("EUR",   DiffFusion.RatesEntry("EUR", nothing, Dict(_empty_key => "EUR"))),
+                ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.AssetEntry}([
+                ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", nothing, nothing, nothing, "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))),
+                ("SXE50",   DiffFusion.AssetEntry("SXE50", nothing, nothing, nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+            ]),
+            Dict{String, DiffFusion.ForwardIndexEntry}([
+                ("HICP", DiffFusion.ForwardIndexEntry("EUR-USD-FWD", nothing, nothing, nothing, "EUR-USD-FWD")),
+            ]),
+            Dict{String, DiffFusion.FutureIndexEntry}([
+                ("NIK", DiffFusion.FutureIndexEntry("NIK", nothing, "NIK-FUT")),
+            ]),
+            Dict{String, DiffFusion.FixingEntry}([
+                ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
+            ]),
+        )
+        det_sim = DiffFusion.Simulation(m, zeros(0), zeros(0,1,0) )
+        p = DiffFusion.path(det_sim, ts, det_context)
+        t = 2.0
+        T = 5.0
+        @test isapprox(DiffFusion.numeraire(p, t, ""), exp(0.03*t) * ones(1), atol=1.0e-15)
+        #
+        @test isapprox(DiffFusion.bank_account(p, t, "USD"), exp(0.03*t) * ones(1), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "EUR"), exp(0.02*t) * ones(1), atol=1.0e-15)
+        @test isapprox(DiffFusion.bank_account(p, t, "SXE50"), exp(0.01*t) * ones(1), atol=1.0e-15)
+        #
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "USD"), exp(-0.03*(T-t)) * ones(1), atol=5.0e-15)
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "EUR"), exp(-0.02*(T-t)) * ones(1), atol=5.0e-15)
+        @test isapprox(DiffFusion.zero_bond(p, t, T, "SXE50"), exp(-0.01*(T-t)) * ones(1), atol=5.0e-15)
+        #
+        @test isapprox(DiffFusion.asset(p, t, "EUR-USD"), 1.25 * exp(0.01*t) * ones(1), atol=5.0e-15)
+        @test isapprox(DiffFusion.asset(p, t, "SXE50"), 3750.00 * exp(0.01*t) * ones(1), atol=5.0e-15)
+        #
+        @test isapprox(DiffFusion.forward_index(p, 4.0, 5.0, "HICP"), 1.25 * ones(1), atol=5.0e-15)
+        #
+        @test isapprox(DiffFusion.future_index(p, 4.0, 5.0, "NIK"), 23776.5 * ones(1), atol=5.0e-15)
+        #
+        @test DiffFusion.fixing(p, -1.0, "SOFR") == 0.0123 * ones(1)
+        #
+    end
+end

--- a/test/unittests/paths/paths.jl
+++ b/test/unittests/paths/paths.jl
@@ -4,5 +4,7 @@ using Test
 @testset "MC path setup and path functions." begin
 
     include("context.jl")
+    include("path.jl")
+    include("simulated_path.jl")
 
 end

--- a/test/unittests/paths/simulated_path.jl
+++ b/test/unittests/paths/simulated_path.jl
@@ -1,0 +1,201 @@
+
+using DiffFusion
+using StatsBase
+using Test
+
+
+@testset "Path simulation and model functions." begin
+    
+    _empty_key = DiffFusion._empty_context_key
+
+    ch_one = DiffFusion.correlation_holder("One")
+    ch_full = DiffFusion.correlation_holder("Full")
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR_f_1", "EUR_f_2", 0.8)
+    DiffFusion.set_correlation!(ch_full, "EUR_f_2", "EUR_f_3", 0.8)
+    DiffFusion.set_correlation!(ch_full, "EUR_f_1", "EUR_f_3", 0.5)
+    #
+    DiffFusion.set_correlation!(ch_full, "USD_f_1", "USD_f_2", 0.50)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "EUR_f_1", -0.30)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "EUR_f_2", -0.30)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "EUR_f_3", -0.30)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "USD_f_1", -0.20)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "USD_f_2", -0.20)
+    #
+    DiffFusion.set_correlation!(ch_full, "USD_f_1", "EUR_f_1", 0.30)
+    DiffFusion.set_correlation!(ch_full, "USD_f_2", "EUR_f_2", 0.30)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "SXE50_x", 0.70)
+
+    setup_models(ch) = begin
+        sigma_fx = DiffFusion.flat_volatility("EUR-USD", 0.15)
+        fx_model = DiffFusion.lognormal_asset_model("EUR-USD", sigma_fx, ch, nothing)
+    
+        sigma_fx = DiffFusion.flat_volatility("SXE50", 0.10)
+        eq_model = DiffFusion.lognormal_asset_model("SXE50-EUR", sigma_fx, ch, fx_model)
+    
+        delta_dom = DiffFusion.flat_parameter([ 1., 7., 15. ])
+        chi_dom = DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ])
+        times_dom =  [ 0. ]
+        values_dom = [ 50. 60. 70. ]' * 1.0e-4
+        sigma_f_dom = DiffFusion.backward_flat_volatility("USD",times_dom,values_dom)
+        hjm_model_dom = DiffFusion.gaussian_hjm_model("USD",delta_dom,chi_dom,sigma_f_dom,ch,nothing)
+    
+        delta_for = DiffFusion.flat_parameter([ 1., 10. ])
+        chi_for = DiffFusion.flat_parameter([ 0.01, 0.15 ])
+        times_for =  [ 0. ]
+        values_for = [ 80. 90. ]' * 1.0e-4
+        sigma_f_for = DiffFusion.backward_flat_volatility("EUR",times_for,values_for)
+        hjm_model_for = DiffFusion.gaussian_hjm_model("EUR",delta_for,chi_for,sigma_f_for,ch,fx_model)
+
+        return [ hjm_model_dom, fx_model, hjm_model_for, eq_model ]
+    end
+
+    context = DiffFusion.Context("Std",
+        DiffFusion.NumeraireEntry("USD", "USD", Dict(_empty_key => "USD")),
+        Dict{String, DiffFusion.RatesEntry}([
+            ("USD",   DiffFusion.RatesEntry("USD", "USD", Dict(_empty_key => "USD", "OIS" => "USD", "NULL" => "ZERO"))),
+            ("EUR",   DiffFusion.RatesEntry("EUR", "EUR", Dict(_empty_key => "EUR", "OIS" => "USD", "NULL" => "ZERO"))),
+            ("SXE50", DiffFusion.RatesEntry("SXE50", nothing, Dict(_empty_key => "SXE50"))),
+        ]),
+        Dict{String, DiffFusion.AssetEntry}([
+            ("EUR-USD", DiffFusion.AssetEntry("EUR-USD", "EUR-USD", "USD", "EUR", "EUR-USD", Dict(_empty_key => "USD"), Dict(_empty_key => "EUR"))), 
+            ("SXE50", DiffFusion.AssetEntry("SXE50", "SXE50-EUR", "EUR", nothing, "SXE50-EUR", Dict(_empty_key => "EUR"), Dict(_empty_key => "SXE50"))),
+        ]),
+        Dict{String, DiffFusion.ForwardIndexEntry}(),
+        Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.FixingEntry}(),
+    )
+
+    # term structures
+    ts = [
+        DiffFusion.flat_forward("USD", 0.03),
+        DiffFusion.flat_forward("EUR", 0.02),
+        DiffFusion.flat_forward("SXE50", 0.01),
+        DiffFusion.flat_parameter("EUR-USD", 1.25),
+        DiffFusion.flat_parameter("SXE50-EUR", 3750.00),
+        DiffFusion.flat_forward("ZERO", 0.00),
+    ]
+
+    @testset "Simple simulation, no correlation" begin
+        models = setup_models(ch_one)
+        m = DiffFusion.simple_model("Std", models)
+        times = [ 0.0, 1.0, 2.0, 4.0, 8.0, 16. ]
+        n_paths = 2^13
+        sim = DiffFusion.simple_simulation(m, ch_one, times, n_paths, with_progress_bar = false)
+        p = DiffFusion.path(sim, ts, context)
+        for t in times[2:end]
+            #
+            num = DiffFusion.numeraire(p, t, "")
+            one = (1.0 / DiffFusion.discount(ts[1], t)) ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol=3.6e-3 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "USD")
+                one = (1.0 / DiffFusion.discount(ts[1], t+dT)) * zcb ./ num
+                # println(abs(mean(one) - 1.0))
+                @test isapprox(mean(one), 1.0, atol=7.0e-3 )
+            end
+            fx = DiffFusion.asset(p, t, "EUR-USD")
+            bd = DiffFusion.bank_account(p, t, "USD")
+            bf = DiffFusion.bank_account(p, t, "EUR")
+            one = bd ./ num  # num = bd!
+            # println(maximum(abs.(one .- 1.0)))
+            @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            one = (1.0/1.25) * bf .* fx ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol=9.8e-3 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "EUR")
+                one = (1.0 / DiffFusion.discount(ts[2], t+dT) / 1.25) * zcb .* fx ./ num
+                # println(abs(mean(one) - 1.0))
+                @test isapprox(mean(one), 1.0, atol=2.5e-2 )
+            end
+            sxe50 = DiffFusion.asset(p, t, "SXE50")
+            bf = DiffFusion.bank_account(p, t, "SXE50")
+            one = bf * DiffFusion.discount(ts[3], t)
+            # println(maximum(abs.(one .- 1.0)))
+            @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            one = (1.0 / 1.25 / 3750.00) * sxe50 .* bf .* fx ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol=1.5e-2 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "SXE50")
+                one = zcb * DiffFusion.discount(ts[3], t) / DiffFusion.discount(ts[3], t+dT)
+                # println(maximum(abs.(one .- 1.0)))
+                @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            end
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                fx_fwd = DiffFusion.forward_asset(p, t, t+dT, "EUR-USD")
+                fx = DiffFusion.asset(p, t, "EUR-USD")
+                zcb_d = DiffFusion.zero_bond(p, t, t+dT, "USD")
+                zcb_f = DiffFusion.zero_bond(p, t, t+dT, "EUR")
+                one = fx_fwd ./ (fx .* zcb_f ./ zcb_d)
+                @test maximum(abs.(one .- 1.0)) < 1.5e-15
+            end
+        end
+    end
+
+    @testset "Simple simulation, full correlation" begin
+        models = setup_models(ch_full)
+        m = DiffFusion.simple_model("Std", models)
+        times = [ 0.0, 1.0, 2.0, 4.0, 8.0, 16. ]
+        n_paths = 2^16
+        sim = DiffFusion.simple_simulation(m, ch_full, times, n_paths, with_progress_bar = false)
+        p = DiffFusion.path(sim, ts, context)
+        for t in times[2:end]
+            #
+            num = DiffFusion.numeraire(p, t, "")
+            one = (1.0 / DiffFusion.discount(ts[1], t)) ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol=1.5e-3 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "USD")
+                one = (1.0 / DiffFusion.discount(ts[1], t+dT)) * zcb ./ num
+                # println(abs(mean(one) - 1.0))
+                @test isapprox(mean(one), 1.0, atol=3.7e-3 )
+            end
+            fx = DiffFusion.asset(p, t, "EUR-USD")
+            bd = DiffFusion.bank_account(p, t, "USD")
+            bf = DiffFusion.bank_account(p, t, "EUR")
+            one = bd ./ num  # num = bd!
+            # println(maximum(abs.(one .- 1.0)))
+            @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            one = (1.0/1.25) * bf .* fx ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol = 3.8e-3 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "EUR")
+                one = (1.0 / DiffFusion.discount(ts[2], t+dT) / 1.25) * zcb .* fx ./ num
+                # println(abs(mean(one) - 1.0))
+                @test isapprox(mean(one), 1.0, atol=6.6e-2 )
+            end
+            sxe50 = DiffFusion.asset(p, t, "SXE50")
+            bf = DiffFusion.bank_account(p, t, "SXE50")
+            one = bf * DiffFusion.discount(ts[3], t)
+            # println(maximum(abs.(one .- 1.0)))
+            @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            one = (1.0 / 1.25 / 3750.00) * sxe50 .* bf .* fx ./ num
+            # println(abs(mean(one) - 1.0))
+            @test isapprox(mean(one), 1.0, atol = VERSION<v"1.7" ? 3.3e-3 : 2.4e-3 )
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                zcb = DiffFusion.zero_bond(p, t, t+dT, "SXE50")
+                one = zcb * DiffFusion.discount(ts[3], t) / DiffFusion.discount(ts[3], t+dT)
+                # println(maximum(abs.(one .- 1.0)))
+                @test maximum(abs.(one .- 1.0)) < 1.0e-15
+            end
+            for dT in [1.0, 2.0, 4.0, 8.0, 16.0]
+                fx_fwd = DiffFusion.forward_asset(p, t, t+dT, "EUR-USD")
+                fx = DiffFusion.asset(p, t, "EUR-USD")
+                zcb_d = DiffFusion.zero_bond(p, t, t+dT, "USD")
+                zcb_f = DiffFusion.zero_bond(p, t, t+dT, "EUR")
+                one = fx_fwd ./ (fx .* zcb_f ./ zcb_d)
+                @test maximum(abs.(one .- 1.0)) < 1.5e-15
+            end
+        end
+    end
+
+
+end


### PR DESCRIPTION
This PR adds a MC Path object and corresponding methods. A Path links Payoffs with Simulations and Models. Path methods represent the critical implementation of analytical model formulas which are used by Payoffs.