### PR TITLE
Add cash flow legs

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -54,6 +54,9 @@ include("payoffs/RatesPayoffs.jl")
 
 include("products/Cashflows.jl")
 include("products/RatesCoupons.jl")
+include("products/CashFlowLeg.jl")
+include("products/MtMCashFlowLeg.jl")
+include("products/CashAndAssetLegs.jl")
 
 include("utils/Integrations.jl")
 include("utils/InterpolationMethods.jl")

--- a/src/products/CashAndAssetLegs.jl
+++ b/src/products/CashAndAssetLegs.jl
@@ -1,0 +1,125 @@
+
+"""
+    struct CashBalance <: CashFlowLeg
+        alias::String
+        notional::ModelValue
+        fx_key::Union{String, Nothing}
+        payer_receiver::ModelValue
+        maturity_time::Union{Nothing, ModelTime}
+    end
+
+A CashLeg represents a constant cash balance in domestic or foreign corrency.
+"""
+struct CashBalanceLeg <: CashFlowLeg
+    alias::String
+    notional::ModelValue
+    fx_key::Union{String, Nothing}
+    payer_receiver::ModelValue
+    maturity_time::Union{Nothing, ModelTime}
+end
+
+
+"""
+    cash_balance_leg(
+        alias::String,
+        notional::ModelValue,
+        fx_key::Union{String, Nothing} = nothing,
+        payer_receiver::ModelValue = +1.0,
+        maturity_time::Union{Nothing, ModelTime} = nothing
+        )
+
+Create a CashBalance object.
+"""
+function cash_balance_leg(
+    alias::String,
+    notional::ModelValue,
+    fx_key::Union{String, Nothing} = nothing,
+    payer_receiver::ModelValue = +1.0,
+    maturity_time::Union{Nothing, ModelTime} = nothing
+    )
+    #
+    @assert notional > 0.0
+    @assert payer_receiver in (+1.0, -1.0)
+    return CashBalanceLeg(alias, notional, fx_key, payer_receiver, maturity_time)
+end
+
+
+"""
+    future_cashflows(leg::CashBalanceLeg, obs_time::ModelTime)
+
+Calculate the list of future undiscounted payoffs in numeraire currency.
+"""
+function future_cashflows(leg::CashBalanceLeg, obs_time::ModelTime)
+    if !isnothing(leg.maturity_time) && (obs_time ≥ leg.maturity_time)
+        return Payoff[]
+    end
+    P = Fixed(leg.payer_receiver * leg.notional)
+    if !isnothing(leg.fx_key)
+        P = Asset(obs_time, leg.fx_key) * P
+    end
+    return [ Pay(P, obs_time) ]
+end
+
+
+"""
+    discounted_cashflows(leg::CashBalanceLeg, obs_time::ModelTime)
+
+Calculate the list of future discounted payoffs in numeraire currency.
+"""
+discounted_cashflows(leg::CashBalanceLeg, obs_time::ModelTime) = future_cashflows(leg, obs_time)
+
+
+"""
+An AssetLeg represents a position in a tradeable asset. Such tradeable asset can be, e.g.,
+a share price, index price or an (FOR-DOM) FX rate where DOM currency differs from
+numeraire currency. 
+"""
+struct AssetLeg <: CashFlowLeg
+    alias::String
+    asset_key::String
+    amount::ModelValue
+    fx_key::Union{String, Nothing}
+    payer_receiver::ModelValue
+    maturity_time::Union{Nothing, ModelTime}
+end
+
+
+function asset_leg(
+    alias::String,
+    asset_key::String,
+    amount::ModelValue,
+    fx_key::Union{String, Nothing} = nothing,
+    payer_receiver::ModelValue = +1.0,
+    maturity_time::Union{Nothing, ModelTime} = nothing,
+    )
+    #
+    @assert amount > 0.0
+    @assert payer_receiver in (+1.0, -1.0)
+    return AssetLeg(alias, asset_key, amount, fx_key, payer_receiver, maturity_time)
+end
+
+
+"""
+    future_cashflows(leg::AssetLeg, obs_time::ModelTime)
+
+Calculate the list of future undiscounted payoffs in numeraire currency.
+"""
+function future_cashflows(leg::AssetLeg, obs_time::ModelTime)
+    if !isnothing(leg.maturity_time) && (obs_time ≥ leg.maturity_time)
+        return Payoff[]
+    end
+    P = (leg.payer_receiver * leg.amount) * Asset(obs_time, leg.asset_key)
+    if !isnothing(leg.fx_key)
+        P = Asset(obs_time, leg.fx_key) * P
+    end
+    return [ Pay(P, obs_time) ]
+end
+
+
+"""
+    discounted_cashflows(leg::AssetLeg, obs_time::ModelTime)
+
+Calculate the list of future discounted payoffs in numeraire currency.
+"""
+discounted_cashflows(leg::AssetLeg, obs_time::ModelTime) = future_cashflows(leg, obs_time)
+

--- a/src/products/CashFlowLeg.jl
+++ b/src/products/CashFlowLeg.jl
@@ -1,0 +1,161 @@
+
+
+"""
+    abstract type CashFlowLeg end
+
+A `CashFlowLeg` combines `CashFlow` objects in a single currency and adds
+notional and payer/receiver information and discounting.
+
+We apply the convention that notionals are non-negative and cash flows
+are modelled from the receiving counter party perspective. This does
+include the exceptions of negative spread cash flows or negative
+notional exchange cash flows.
+"""
+abstract type CashFlowLeg end
+
+"""
+    alias(leg::CashFlowLeg)
+
+Return the leg alias
+"""
+alias(leg::CashFlowLeg) = leg.alias
+
+"""
+    future_cashflows(leg::CashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future undiscounted payoffs in numeraire currency.
+"""
+function future_cashflows(leg::CashFlowLeg, obs_time::ModelTime)
+    error("CashFlowLeg needs to implement future_cashflows method.")
+end
+
+"""
+    discounted_cashflows(leg::CashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future discounted payoffs in numeraire currency.
+"""
+function discounted_cashflows(leg::CashFlowLeg, obs_time::ModelTime)
+    error("CashFlowLeg needs to implement discounted_cashflows method.")
+end
+
+
+"""
+    struct DeterministicCashFlowLeg <: CashFlowLeg
+        alias::String
+        cashflows::AbstractVector
+        notionals::AbstractVector
+        curve_key::String
+        fx_key::Union{String, Nothing}
+        payer_receiver::ModelValue
+    end
+
+A DeterministicCashFlowLeg models legs with deterministic notionals.
+"""
+struct DeterministicCashFlowLeg <: CashFlowLeg
+    alias::String
+    cashflows::AbstractVector
+    notionals::AbstractVector
+    curve_key::String
+    fx_key::Union{String, Nothing}
+    payer_receiver::ModelValue
+end
+
+"""
+    cashflow_leg(
+        alias::String,
+        cashflows::AbstractVector,
+        notionals::AbstractVector,
+        curve_key::Union{String, Nothing} = nothing,
+        fx_key::Union{String, Nothing} = nothing,
+        payer_receiver = 1.0,
+        )
+
+Create a DeterministicCashFlowLeg.
+"""
+function cashflow_leg(
+    alias::String,
+    cashflows::AbstractVector,
+    notionals::AbstractVector,
+    curve_key::Union{String, Nothing} = nothing,
+    fx_key::Union{String, Nothing} = nothing,
+    payer_receiver = 1.0,
+    )
+    #
+    @assert length(cashflows) > 0
+    @assert length(cashflows) == length(notionals)
+    @assert payer_receiver in (-1.0, 1.0)
+    if isnothing(curve_key)
+        # try to infer curve key from the cashflows
+        @assert hasproperty(cashflows[begin], :curve_key)
+        curve_key = cashflows[begin].curve_key
+    end
+    return DeterministicCashFlowLeg(alias, cashflows, notionals, curve_key, fx_key, payer_receiver)
+end
+
+"""
+    cashflow_leg(
+        alias::String,
+        cashflows::AbstractVector,
+        notional::ModelValue,
+        curve_key::Union{String, Nothing} = nothing,
+        fx_key::Union{String, Nothing} = nothing,
+        payer_receiver = 1.0,
+        )
+
+Create a constant notional CashFlowLeg.
+"""
+function cashflow_leg(
+    alias::String,
+    cashflows::AbstractVector,
+    notional::ModelValue,
+    curve_key::Union{String, Nothing} = nothing,
+    fx_key::Union{String, Nothing} = nothing,
+    payer_receiver = 1.0,
+    )
+    #
+    @assert length(cashflows) > 0
+    @assert notional > 0.0
+    notionals = notional * ones(length(cashflows))
+    return cashflow_leg(alias, cashflows, notionals, curve_key, fx_key, payer_receiver)
+end
+
+
+"""
+    future_cashflows(leg::DeterministicCashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future undiscounted payoffs in numeraire currency.
+"""
+function future_cashflows(leg::DeterministicCashFlowLeg, obs_time::ModelTime)
+    payoffs = Payoff[]
+    for (cf, notional) in zip(leg.cashflows, leg.notionals)
+        if pay_time(cf) > obs_time
+            P = (leg.payer_receiver * notional) * amount(cf)
+            if !isnothing(leg.fx_key)
+                P = Asset(pay_time(cf), leg.fx_key) * P
+            end
+            push!(payoffs, Pay(P, pay_time(cf)))
+        end
+    end
+    return payoffs
+end
+
+
+"""
+    discounted_cashflows(leg::DeterministicCashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future discounted payoffs in numeraire currency.
+"""
+function discounted_cashflows(leg::DeterministicCashFlowLeg, obs_time::ModelTime)
+    payoffs = Payoff[]
+    for (cf, notional) in zip(leg.cashflows, leg.notionals)
+        if pay_time(cf) > obs_time
+            P = (leg.payer_receiver * notional) * expected_amount(cf, obs_time)
+            P = ZeroBond(obs_time, pay_time(cf), leg.curve_key) * P
+            if !isnothing(leg.fx_key)
+                P = Asset(obs_time, leg.fx_key) * P
+            end
+            push!(payoffs, Pay(P, obs_time))
+        end
+    end
+    return payoffs
+end

--- a/src/products/MtMCashFlowLeg.jl
+++ b/src/products/MtMCashFlowLeg.jl
@@ -1,0 +1,235 @@
+
+"""
+    struct MtMCashFlowLeg <: CashFlowLeg
+        alias::String
+        cashflows::AbstractVector
+        intitial_notional::ModelValue
+        curve_key_dom::String
+        curve_key_for::String
+        fx_key_dom::Union{String, Nothing}
+        fx_key_for::Union{String, Nothing}
+        fx_reset_times::AbstractVector
+        fx_pay_times::AbstractVector
+        payer_receiver::ModelValue
+    end
+
+A mark-to-market (MtM) cross currency cash flow leg adds notional resets
+to the cash flow payments.
+
+Notional resets are calculated from FX rates at reset times.
+
+We consider a setting with numeraire currency, domestic currency and
+foreign currency.
+
+Cash flows are denominated in domestic currency. Initial notional is
+expressed in foreign currency and simulation is modelled in numeraire
+currency.
+
+We denote `fx_key_for` the FOR-NUM asset key and `fx_key_dom` the
+DOM-NUM asset key.
+
+FX rates for notional exchange are fixed at `fx_reset_times` and notional
+cash flows are exchanged at `fx_pay_times`. The very first notional exchange
+is not modelled because it is either in the past or foreign and domestic
+notional exchange offset each other.
+
+As a consequence, we have one `fx_reset_time` and one `fx_pay_time` per cash flow.
+The `fx_reset_time` is at (or before) the start of the coupon period and
+`fx_pay_time` is at (or after) the end of the coupon period.
+
+"""
+struct MtMCashFlowLeg <: CashFlowLeg
+    alias::String
+    cashflows::AbstractVector
+    intitial_notional::ModelValue
+    curve_key_dom::String
+    curve_key_for::String
+    fx_key_dom::Union{String, Nothing}
+    fx_key_for::Union{String, Nothing}
+    fx_reset_times::AbstractVector
+    fx_pay_times::AbstractVector
+    payer_receiver::ModelValue
+end
+
+
+"""
+    mtm_cashflow_leg(
+        alias::String,
+        cashflows::AbstractVector,
+        intitial_notional::ModelValue,
+        curve_key_dom::String,
+        curve_key_for::String,
+        fx_key_dom::Union{String, Nothing},
+        fx_key_for::Union{String, Nothing},
+        fx_reset_times::AbstractVector,
+        fx_pay_times::AbstractVector,
+        payer_receiver::ModelValue,
+        )
+
+Create a MTM cash flow leg.
+"""
+function mtm_cashflow_leg(
+    alias::String,
+    cashflows::AbstractVector,
+    intitial_notional::ModelValue,
+    curve_key_dom::String,
+    curve_key_for::String,
+    fx_key_dom::Union{String, Nothing},
+    fx_key_for::Union{String, Nothing},
+    fx_reset_times::AbstractVector,
+    fx_pay_times::AbstractVector,
+    payer_receiver::ModelValue,
+    )
+    #
+    @assert length(cashflows) > 0
+    @assert intitial_notional > 0
+    @assert length(fx_reset_times) == length(cashflows)
+    @assert length(fx_pay_times) == length(cashflows)
+    @assert payer_receiver in (-1.0, 1.0)
+    #
+    @assert fx_pay_times[1] >= fx_reset_times[1]
+    for k in 2:length(cashflows)
+        @assert pay_time(cashflows[k]) >  pay_time(cashflows[k-1])
+        @assert fx_pay_times[k]        >= fx_reset_times[k]
+        @assert fx_pay_times[k]        >  fx_pay_times[k-1]
+        @assert fx_reset_times[k]      >  fx_reset_times[k-1]
+    end
+    return MtMCashFlowLeg(alias, cashflows, intitial_notional, curve_key_dom, curve_key_for,
+        fx_key_dom, fx_key_for, fx_reset_times, fx_pay_times, payer_receiver)
+end
+
+"""
+    mtm_cashflow_leg(
+        alias::String,
+        leg::DeterministicCashFlowLeg,
+        intitial_notional::ModelValue,  # in foreign currency
+        initial_reset_time::ModelValue,
+        curve_key_for::String,
+        fx_key_for::Union{String, Nothing},
+        )
+
+Create a MtM cash flow leg from a deterministic leg.
+"""
+function mtm_cashflow_leg(
+    alias::String,
+    leg::DeterministicCashFlowLeg,
+    intitial_notional::ModelValue,  # in foreign currency
+    initial_reset_time::ModelValue,
+    curve_key_for::String,
+    fx_key_for::Union{String, Nothing},
+    )
+    #
+    fx_pay_times = [ pay_time(cf) for cf in leg.cashflows ]
+    fx_reset_times = vcat(
+        [ initial_reset_time ], fx_pay_times[begin:end-1]
+    )
+    return mtm_cashflow_leg(
+        alias,
+        leg.cashflows,
+        intitial_notional,
+        leg.curve_key,
+        curve_key_for,
+        leg.fx_key,
+        fx_key_for,
+        fx_reset_times,
+        fx_pay_times,
+        leg.payer_receiver,
+    )
+end
+
+
+"""
+    future_cashflows(leg::MtMCashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future undiscounted payoffs in numeraire currency.
+"""
+function future_cashflows(leg::MtMCashFlowLeg, obs_time::ModelTime)
+    # we need the FX rate FOR-DOM via triangulation.
+    fx_for_dom(t) = begin
+        if isnothing(leg.fx_key_dom) && isnothing(leg.fx_key_for)
+            return 1.0
+        end
+        if isnothing(leg.fx_key_dom)
+            return Asset(t, leg.fx_key_for)
+        end
+        if isnothing(leg.fx_key_for)
+            return 1.0 / Asset(t, leg.fx_key_dom)
+        end
+        return Asset(t, leg.fx_key_for) / Asset(t, leg.fx_key_dom)
+    end
+    payoffs = Payoff[]
+    for (k, cf) in enumerate(leg.cashflows)
+        if pay_time(cf) > obs_time
+            dom_notional = fx_for_dom(leg.fx_reset_times[k]) * (leg.payer_receiver * leg.intitial_notional)
+            P = dom_notional * amount(cf)
+            if !isnothing(leg.fx_key_dom)
+                P = Asset(pay_time(cf), leg.fx_key_dom) * P
+            end
+            push!(payoffs, Pay(P, pay_time(cf)))
+        end
+        if leg.fx_pay_times[k] > obs_time
+            P = (fx_for_dom(leg.fx_reset_times[k]) - fx_for_dom(leg.fx_pay_times[k]))
+            P = P * (leg.payer_receiver * leg.intitial_notional)
+            if !isnothing(leg.fx_key_dom)
+                P = Asset(leg.fx_pay_times[k], leg.fx_key_dom) * P
+            end
+            if !isa(P, Payoff)
+                P = Fixed(P)
+            end
+            push!(payoffs, Pay(P, leg.fx_pay_times[k]))
+        end
+    end
+    return payoffs
+end
+
+
+"""
+    discounted_cashflows(leg::MtMCashFlowLeg, obs_time::ModelTime)
+
+Calculate the list of future discounted payoffs in numeraire currency.
+"""
+function discounted_cashflows(leg::MtMCashFlowLeg, obs_time::ModelTime)
+    # we need the FX rate FOR-DOM via triangulation.
+    fx_for_dom(t) = begin
+        if isnothing(leg.fx_key_dom) && isnothing(leg.fx_key_for)
+            return 1.0
+        end
+        if isnothing(leg.fx_key_dom)
+            return Asset(t, leg.fx_key_for)
+        end
+        if isnothing(leg.fx_key_for)
+            return 1.0 / Asset(t, leg.fx_key_dom)
+        end
+        return Asset(t, leg.fx_key_for) / Asset(t, leg.fx_key_dom)
+    end
+    fwd_fx_for_dom(t) = begin
+        if t <= obs_time
+            return fx_for_dom(t)  #  rate is fixed already
+        end
+        # we must not look into the future and use T-forward expectation
+        return fx_for_dom(obs_time) * ZeroBond(obs_time, t, leg.curve_key_for) / ZeroBond(obs_time, t, leg.curve_key_dom)
+    end
+    payoffs = Payoff[]
+    for (k, cf) in enumerate(leg.cashflows)
+        if pay_time(cf) > obs_time
+            dom_notional = fwd_fx_for_dom(leg.fx_reset_times[k]) * (leg.payer_receiver * leg.intitial_notional)
+            P = dom_notional * ZeroBond(obs_time, pay_time(cf), leg.curve_key_dom) * expected_amount(cf, obs_time)
+            if !isnothing(leg.fx_key_dom)
+                P = Asset(obs_time, leg.fx_key_dom) * P
+            end
+            push!(payoffs, Pay(P, obs_time))
+        end
+        if leg.fx_pay_times[k] > obs_time
+            P = (fwd_fx_for_dom(leg.fx_reset_times[k]) - fwd_fx_for_dom(leg.fx_pay_times[k]))
+            P = ZeroBond(obs_time, leg.fx_pay_times[k], leg.curve_key_dom) * P * (leg.payer_receiver * leg.intitial_notional)
+            if !isnothing(leg.fx_key_dom)
+                P =  Asset(obs_time, leg.fx_key_dom) * P
+            end
+            if !isa(P, Payoff)
+                P = Fixed(P)
+            end
+            push!(payoffs, Pay(P, obs_time))
+        end
+    end
+    return payoffs
+end

--- a/test/unittests/products/cash_and_asset_legs.jl
+++ b/test/unittests/products/cash_and_asset_legs.jl
@@ -1,0 +1,45 @@
+
+using DiffFusion
+using Test
+
+@testset "Test cash and asset legs" begin
+    
+    @testset "Test CashBalanceLeg." begin
+        leg = DiffFusion.cash_balance_leg("leg/1", 100.0)
+        p = DiffFusion.discounted_cashflows(leg, 5.0)
+        @test length(p) == 1
+        @test string(p[1]) == "(100.0000 @ 5.00)"
+        #
+        leg = DiffFusion.cash_balance_leg("leg/1", 100.0, "EUR-USD", -1)
+        p = DiffFusion.discounted_cashflows(leg, 1.0)
+        @test string(p[1]) == "(S(EUR-USD, 1.00) * -100.0000 @ 1.00)"
+        #
+        leg = DiffFusion.cash_balance_leg("leg/1", 100.0, nothing, -1, 3.0)
+        p = DiffFusion.discounted_cashflows(leg, 1.0)
+        @test string(p[1]) == "(-100.0000 @ 1.00)"
+        @test length(DiffFusion.discounted_cashflows(leg, 3.0)) == 0
+        @test length(DiffFusion.discounted_cashflows(leg, 5.0)) == 0
+        # println(string(p[1]))
+    end
+
+
+    @testset "Test CashBalanceLeg." begin
+        leg = DiffFusion.asset_leg("leg/1", "SXE50", 100.0)
+        p = DiffFusion.discounted_cashflows(leg, 5.0)
+        @test length(p) == 1
+        @test string(p[1]) == "(100.0000 * S(SXE50, 5.00) @ 5.00)"
+        #
+        leg = DiffFusion.asset_leg("leg/1", "SXE50", 100.0, "EUR-USD", -1)
+        p = DiffFusion.discounted_cashflows(leg, 1.0)
+        @test string(p[1]) == "(S(EUR-USD, 1.00) * -100.0000 * S(SXE50, 1.00) @ 1.00)"
+        #
+        leg = DiffFusion.asset_leg("leg/1", "SXE50", 100.0, nothing, -1, 3.0)
+        p = DiffFusion.discounted_cashflows(leg, 1.0)
+        @test string(p[1]) == "(-100.0000 * S(SXE50, 1.00) @ 1.00)"
+        @test length(DiffFusion.discounted_cashflows(leg, 3.0)) == 0
+        @test length(DiffFusion.discounted_cashflows(leg, 5.0)) == 0
+        # println(string(p[1]))
+    end
+
+
+end

--- a/test/unittests/products/cashflow_leg.jl
+++ b/test/unittests/products/cashflow_leg.jl
@@ -1,0 +1,75 @@
+
+using DiffFusion
+using Test
+
+@testset "CashFlowLeg tests." begin
+
+    @testset "Abstract CashFlowLeg." begin
+        struct NoLeg <: DiffFusion.CashFlowLeg end
+        @test_throws ErrorException DiffFusion.future_cashflows(NoLeg(), 2.0)
+        @test_throws ErrorException DiffFusion.discounted_cashflows(NoLeg(), 2.0)
+    end
+
+    @testset "Deterministic notional legs" begin
+        cash_flows = [
+            DiffFusion.FixedCashFlow(-1.0, 0.5),
+            DiffFusion.FixedCashFlow( 0.0, 0.5),
+            DiffFusion.FixedCashFlow( 1.0, 0.5),
+            DiffFusion.FixedRateCoupon(2.0, 0.03, 1.0),
+            DiffFusion.FixedRateCoupon(3.0, 0.03, 1.0),
+            DiffFusion.SimpleRateCoupon(3.0, 3.0, 4.0, 4.0, 1.0, "EURIBOR12M", nothing, 0.01)
+        ]
+        notionals = [ 10., 20., 30., 40., 50., 60., ]
+        #
+        leg = DiffFusion.cashflow_leg("One",cash_flows, notionals, "EUR:OIS")
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 4
+        @test string(payoffs[1]) == "(30.0000 * 0.5000 @ 1.00)"
+        @test string(payoffs[4]) == "(60.0000 * (L(EURIBOR12M, 3.00; 3.00, 4.00) + 0.0100) * 1.0000 @ 4.00)"
+        #
+        payoffs = DiffFusion.future_cashflows(leg, 2.5)
+        @test length(payoffs) == 2
+        @test string(payoffs[1]) == "(50.0000 * 0.0300 * 1.0000 @ 3.00)"
+        @test string(payoffs[2]) == "(60.0000 * (L(EURIBOR12M, 3.00; 3.00, 4.00) + 0.0100) * 1.0000 @ 4.00)"
+        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 2.5)
+        @test length(payoffs) == 2
+        @test string(payoffs[1]) == "(P(EUR:OIS, 2.50, 3.00) * 50.0000 * 0.0300 * 1.0000 @ 2.50)"
+        @test string(payoffs[2]) == "(P(EUR:OIS, 2.50, 4.00) * 60.0000 * (L(EURIBOR12M, 2.50; 3.00, 4.00) + 0.0100) * 1.0000 @ 2.50)"
+        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 3.5)
+        @test length(payoffs) == 1
+        @test string(payoffs[1]) == "(P(EUR:OIS, 3.50, 4.00) * 60.0000 * (L(EURIBOR12M, 3.00; 3.00, 4.00) + 0.0100) * 1.0000 @ 3.50)"
+        #
+        notionals = 100.0 * ones(6)
+        leg2 = DiffFusion.cashflow_leg("Two",cash_flows, notionals, "EUR:OIS")
+        leg3 = DiffFusion.cashflow_leg("Two",cash_flows, 100.0, "EUR:OIS")
+        @test leg2.alias == leg3.alias
+        @test leg2.cashflows == leg3.cashflows
+        @test leg2.notionals == leg3.notionals
+        @test leg2.curve_key == leg3.curve_key
+        @test leg2.fx_key == leg3.fx_key
+        @test leg2.payer_receiver == leg3.payer_receiver
+        #
+        leg = DiffFusion.cashflow_leg("Two",cash_flows, 100.0, "EUR:OIS", "EUR-USD")
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 4
+        @test string(payoffs[4]) == "(S(EUR-USD, 4.00) * 100.0000 * (L(EURIBOR12M, 3.00; 3.00, 4.00) + 0.0100) * 1.0000 @ 4.00)"
+        payoffs = DiffFusion.discounted_cashflows(leg, 3.5)
+        @test length(payoffs) == 1
+        @test string(payoffs[1]) == "(S(EUR-USD, 3.50) * P(EUR:OIS, 3.50, 4.00) * 100.0000 * (L(EURIBOR12M, 3.00; 3.00, 4.00) + 0.0100) * 1.0000 @ 3.50)"
+        #
+        leg = DiffFusion.cashflow_leg("Two",cash_flows, 100.0, "EUR:OIS", "EUR-USD", -1)
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 4
+        @test string(payoffs[1]) == "(S(EUR-USD, 1.00) * -100.0000 * 0.5000 @ 1.00)"
+        #
+        leg = DiffFusion.cashflow_leg("Two",cash_flows[end:end], 100.0)
+        @test leg.curve_key == "EURIBOR12M"
+        #
+        @test_throws AssertionError DiffFusion.cashflow_leg("Two",cash_flows, 100.0)
+        @test_throws AssertionError DiffFusion.cashflow_leg("Two",cash_flows, 0.0, "EUR:OIS")
+        @test_throws AssertionError DiffFusion.cashflow_leg("Two",cash_flows, notionals[2:end], "EUR:OIS")
+    end
+
+end

--- a/test/unittests/products/mtm_cashflow_leg.jl
+++ b/test/unittests/products/mtm_cashflow_leg.jl
@@ -1,0 +1,278 @@
+
+using DiffFusion
+using Test
+
+@testset "CashFlowLeg tests." begin
+
+    @testset "Mark-to-mark legs flows" begin
+        cash_flows = [
+            DiffFusion.FixedCashFlow(2.0, 0.01)
+            DiffFusion.FixedCashFlow(3.0, 0.01)
+            DiffFusion.FixedCashFlow(4.0, 0.01)
+        ]
+        intitial_notional = 100. # GBP
+        curve_key_dom = "EUR:XCCY"
+        curve_key_for = "GBP:XCCY"
+        fx_key_dom = "EUR-USD"
+        fx_key_for = "GBP-USD"
+        fx_reset_times = [ 1.0, 2.0, 3.0 ]
+        fx_pay_times   = [ 2.0, 3.0, 4.0 ]
+        payer_receiver = 1.0
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            fx_key_dom,
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(S(EUR-USD, 4.00) * (S(GBP-USD, 3.00) / S(EUR-USD, 3.00)) * 100.0000 * 0.0100 @ 4.00)"
+        @test string(payoffs[6]) == "(S(EUR-USD, 4.00) * ((S(GBP-USD, 3.00) / S(EUR-USD, 3.00)) - (S(GBP-USD, 4.00) / S(EUR-USD, 4.00))) * 100.0000 @ 4.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            nothing, # DOM = NUM
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(S(GBP-USD, 3.00) * 100.0000 * 0.0100 @ 4.00)"
+        @test string(payoffs[6]) == "((S(GBP-USD, 3.00) - S(GBP-USD, 4.00)) * 100.0000 @ 4.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            fx_key_dom,
+            nothing, # FOR = NUM
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(S(EUR-USD, 4.00) * (1.0000 / S(EUR-USD, 3.00)) * 100.0000 * 0.0100 @ 4.00)"
+        @test string(payoffs[6]) == "(S(EUR-USD, 4.00) * ((1.0000 / S(EUR-USD, 3.00)) - (1.0000 / S(EUR-USD, 4.00))) * 100.0000 @ 4.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            nothing, # DOM = NUM
+            nothing, # FOR = NUM
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.future_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(100.0000 * 0.0100 @ 4.00)"
+        @test string(payoffs[6]) == "(0.0000 @ 4.00)"
+        #for p in payoffs
+        #    println(string(p))
+        #end
+    end
+
+    @testset "Mark-to-mark discounted legs flows as of t=0" begin
+        cash_flows = [
+            DiffFusion.FixedCashFlow(2.0, 0.01)
+            DiffFusion.FixedCashFlow(3.0, 0.01)
+            DiffFusion.FixedCashFlow(4.0, 0.01)
+        ]
+        intitial_notional = 100. # GBP
+        curve_key_dom = "EUR:XCCY"
+        curve_key_for = "GBP:XCCY"
+        fx_key_dom = "EUR-USD"
+        fx_key_for = "GBP-USD"
+        fx_reset_times = [ 1.0, 2.0, 3.0 ]
+        fx_pay_times   = [ 2.0, 3.0, 4.0 ]
+        payer_receiver = 1.0
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            fx_key_dom,
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(S(EUR-USD, 0.00) * ((S(GBP-USD, 0.00) / S(EUR-USD, 0.00)) * P(GBP:XCCY, 0.00, 3.00) / P(EUR:XCCY, 0.00, 3.00)) * 100.0000 * P(EUR:XCCY, 0.00, 4.00) * 0.0100 @ 0.00)"
+        @test string(payoffs[6]) == "(S(EUR-USD, 0.00) * P(EUR:XCCY, 0.00, 4.00) * (((S(GBP-USD, 0.00) / S(EUR-USD, 0.00)) * P(GBP:XCCY, 0.00, 3.00) / P(EUR:XCCY, 0.00, 3.00)) - ((S(GBP-USD, 0.00) / S(EUR-USD, 0.00)) * P(GBP:XCCY, 0.00, 4.00) / P(EUR:XCCY, 0.00, 4.00))) * 100.0000 @ 0.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            "USD:OIS",
+            curve_key_for,
+            nothing, # DOM = NUM
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "((S(GBP-USD, 0.00) * P(GBP:XCCY, 0.00, 3.00) / P(USD:OIS, 0.00, 3.00)) * 100.0000 * P(USD:OIS, 0.00, 4.00) * 0.0100 @ 0.00)"
+        @test string(payoffs[6]) == "(P(USD:OIS, 0.00, 4.00) * ((S(GBP-USD, 0.00) * P(GBP:XCCY, 0.00, 3.00) / P(USD:OIS, 0.00, 3.00)) - (S(GBP-USD, 0.00) * P(GBP:XCCY, 0.00, 4.00) / P(USD:OIS, 0.00, 4.00))) * 100.0000 @ 0.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            "USD:OIS",
+            fx_key_dom,
+            nothing, # FOR = NUM
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "(S(EUR-USD, 0.00) * ((1.0000 / S(EUR-USD, 0.00)) * P(USD:OIS, 0.00, 3.00) / P(EUR:XCCY, 0.00, 3.00)) * 100.0000 * P(EUR:XCCY, 0.00, 4.00) * 0.0100 @ 0.00)"
+        @test string(payoffs[6]) == "(S(EUR-USD, 0.00) * P(EUR:XCCY, 0.00, 4.00) * (((1.0000 / S(EUR-USD, 0.00)) * P(USD:OIS, 0.00, 3.00) / P(EUR:XCCY, 0.00, 3.00)) - ((1.0000 / S(EUR-USD, 0.00)) * P(USD:OIS, 0.00, 4.00) / P(EUR:XCCY, 0.00, 4.00))) * 100.0000 @ 0.00)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            "USD:OIS",
+            "USD:OIS",
+            nothing, # DOM = NUM
+            nothing, # FOR = NUM
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 0.0)
+        @test length(payoffs) == 6
+        @test string(payoffs[5]) == "((1.0000 * P(USD:OIS, 0.00, 3.00) / P(USD:OIS, 0.00, 3.00)) * 100.0000 * P(USD:OIS, 0.00, 4.00) * 0.0100 @ 0.00)"
+        @test string(payoffs[6]) == "(P(USD:OIS, 0.00, 4.00) * ((1.0000 * P(USD:OIS, 0.00, 3.00) / P(USD:OIS, 0.00, 3.00)) - (1.0000 * P(USD:OIS, 0.00, 4.00) / P(USD:OIS, 0.00, 4.00))) * 100.0000 @ 0.00)"
+        # for p in payoffs
+        #     println(string(p))
+        #     println(DiffFusion.obs_times(p))
+        # end
+        # println()
+    end
+
+    @testset "Mark-to-mark discounted legs flows as of t>0" begin
+        cash_flows = [
+            DiffFusion.FixedCashFlow(2.0, 0.01)
+            DiffFusion.FixedCashFlow(3.0, 0.01)
+            DiffFusion.FixedCashFlow(4.0, 0.01)
+        ]
+        intitial_notional = 100. # GBP
+        curve_key_dom = "EUR:XCCY"
+        curve_key_for = "GBP:XCCY"
+        fx_key_dom = "EUR-USD"
+        fx_key_for = "GBP-USD"
+        fx_reset_times = [ 1.0, 2.0, 3.0 ]
+        fx_pay_times   = [ 2.0, 3.0, 4.0 ]
+        payer_receiver = 1.0
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            curve_key_dom,
+            curve_key_for,
+            fx_key_dom,
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 2.5)
+        @test length(payoffs) == 4
+        @test string(payoffs[1]) == "(S(EUR-USD, 2.50) * (S(GBP-USD, 2.00) / S(EUR-USD, 2.00)) * 100.0000 * P(EUR:XCCY, 2.50, 3.00) * 0.0100 @ 2.50)"
+        @test string(payoffs[2]) == "(S(EUR-USD, 2.50) * P(EUR:XCCY, 2.50, 3.00) * ((S(GBP-USD, 2.00) / S(EUR-USD, 2.00)) - ((S(GBP-USD, 2.50) / S(EUR-USD, 2.50)) * P(GBP:XCCY, 2.50, 3.00) / P(EUR:XCCY, 2.50, 3.00))) * 100.0000 @ 2.50)"
+        #
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-EUR-Swap",
+            cash_flows,
+            intitial_notional,
+            "USD:OIS",
+            curve_key_for,
+            nothing, # DOM = NUM
+            fx_key_for,
+            fx_reset_times,
+            fx_pay_times,
+            payer_receiver,
+        )        #
+        payoffs = DiffFusion.discounted_cashflows(leg, 2.5)
+        @test length(payoffs) == 4
+        @test string(payoffs[1]) == "(S(GBP-USD, 2.00) * 100.0000 * P(USD:OIS, 2.50, 3.00) * 0.0100 @ 2.50)"
+        @test string(payoffs[2]) == "(P(USD:OIS, 2.50, 3.00) * (S(GBP-USD, 2.00) - (S(GBP-USD, 2.50) * P(GBP:XCCY, 2.50, 3.00) / P(USD:OIS, 2.50, 3.00))) * 100.0000 @ 2.50)"
+        # for p in payoffs
+        #     println(string(p))
+        #     println(DiffFusion.obs_times(p))
+        # end
+        # println()
+    end
+
+    @testset "Mark-to-mark leg from deterministic leg" begin
+        cash_flows = [
+            DiffFusion.FixedCashFlow(2.0, 0.01)
+            DiffFusion.FixedCashFlow(3.0, 0.01)
+            DiffFusion.FixedCashFlow(4.0, 0.01)
+        ]
+        intitial_notional = 100. # GBP
+        initial_reset_time = 1.0
+        curve_key_for = "GBP:XCCY"
+        fx_key_for = "GBP-USD"
+        payer_receiver = 1.0
+        #
+        determ_leg = DiffFusion.cashflow_leg(
+            "GBP-USD-Swap",
+            cash_flows,
+            ones(length(cash_flows)),
+            "USD:OIS",
+            nothing,
+            payer_receiver,
+        )
+        leg = DiffFusion.mtm_cashflow_leg(
+            "GBP-USD-Swap",
+            determ_leg,
+            intitial_notional,
+            initial_reset_time,
+            curve_key_for,
+            fx_key_for,
+        )
+        payoffs = DiffFusion.discounted_cashflows(leg, 2.5)
+        @test length(payoffs) == 4
+        @test string(payoffs[1]) == "(S(GBP-USD, 2.00) * 100.0000 * P(USD:OIS, 2.50, 3.00) * 0.0100 @ 2.50)"
+        @test string(payoffs[2]) == "(P(USD:OIS, 2.50, 3.00) * (S(GBP-USD, 2.00) - (S(GBP-USD, 2.50) * P(GBP:XCCY, 2.50, 3.00) / P(USD:OIS, 2.50, 3.00))) * 100.0000 @ 2.50)"
+        #for p in payoffs
+        #    println(string(p))
+        #    println(DiffFusion.obs_times(p))
+        #end
+        #println()
+    end
+
+
+end

--- a/test/unittests/products/products.jl
+++ b/test/unittests/products/products.jl
@@ -5,5 +5,8 @@ using Test
 
     include("cashflows.jl")
     include("rates_coupons.jl")
+    include("cashflow_leg.jl")
+    include("mtm_cashflow_leg.jl")
+    include("cash_and_asset_legs.jl")
 
 end


### PR DESCRIPTION
This PR adds CashFlowLegs as bulding block for financial product representations
 - deterministic notional cash flow leg
 - fx-resetting notional cash flow leg
 - cash leg and asset leg (to model cash and asset balances)