### PR TITLE
Update makedocs for Documenter v1.0.0

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,6 +38,7 @@ makedocs(
         "pages/additional_functions.md",
         "pages/function_index.md",
     ],
+    warnonly = [:missing_docs, ],
 )
 
 deploydocs(


### PR DESCRIPTION
With this PR we fix breaking changes introduced by Documenter v1.0.0
 - do not error on missing docs