### PR TITLE
Add test_arg for runtest  

### DIFF
--- a/.github/workflows/CI_componenttests.yml
+++ b/.github/workflows/CI_componenttests.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1.9'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: sschlenkrich/julia-runtest@with_test_arg_v2
+        with:
+          test_arg: 'componenttests/componenttests.jl'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,16 @@ using Logging
 
 @testset verbose=true "DiffFusion.jl" begin
 
-    include("unittests/unittests.jl")
+    if @isdefined(ARGS) && length(ARGS) > 0
+        @info "Run tests " * ARGS[1] * " from test_args."
+        @testset verbose=true "Runtests" begin
+            include(ARGS[1])
+        end
+    else
+        @testset verbose=true "Unit tests" begin
+            include("unittests/unittests.jl")
+        end
+    end
 
 end
 


### PR DESCRIPTION
This PR adds the feature to allow running specific tests via runtests.jl. The feature is applied to set up a GitHub action to run component tests.