### PR TITLE
Add LinearZeroCurve

### DIFF
--- a/src/serialisation/RebuildTermstructures.jl
+++ b/src/serialisation/RebuildTermstructures.jl
@@ -41,6 +41,22 @@ end
 
 
 """
+    _get_labels_and_values(ts::LinearZeroCurve)
+
+Extract labels and values from LinearZeroCurve.
+"""
+function _get_labels_and_values(ts::LinearZeroCurve)
+    param_labels = [
+        alias(ts) * _split_alias_identifyer *
+        string(typeof(ts)) * _split_alias_identifyer *
+        (@sprintf("%.2f", t))
+        for t in ts.times
+    ]
+    return ( param_labels, ts.values )
+end
+
+
+"""
     _get_labels_and_values(ts::PiecewiseFlatParameter)
 
 Extract labels and values from PiecewiseFlatParameter.
@@ -100,6 +116,10 @@ function termstructure_dictionary!(
         end
         if isa(ts_dict[ts_alias], ZeroCurve)
             ts_dict[ts_alias] = zero_curve(ts_dict[ts_alias].alias, ts_dict[ts_alias].times, values)
+            continue
+        end
+        if isa(ts_dict[ts_alias], LinearZeroCurve)
+            ts_dict[ts_alias] = linear_zero_curve(ts_dict[ts_alias].alias, ts_dict[ts_alias].times, values)
             continue
         end
         if isa(ts_dict[ts_alias], BackwardFlatParameter)

--- a/src/serialisation/RebuildTermstructures.jl
+++ b/src/serialisation/RebuildTermstructures.jl
@@ -115,6 +115,7 @@ function termstructure_dictionary!(
             continue
         end
         if isa(ts_dict[ts_alias], ZeroCurve)
+            @warn "ZeroCurve rebuild does not work with Zygote. Consider using LinearZeroCurve."
             ts_dict[ts_alias] = zero_curve(ts_dict[ts_alias].alias, ts_dict[ts_alias].times, values)
             continue
         end

--- a/src/serialisation/Termstructures.jl
+++ b/src/serialisation/Termstructures.jl
@@ -22,6 +22,13 @@ function serialise(o::ZeroCurve)
 end
 
 """
+    serialise(o::LinearZeroCurve)
+
+    Serialise LinearZeroCurve.
+"""
+serialise(o::LinearZeroCurve) = serialise_struct(o)
+
+"""
     serialise(o::BackwardFlatVolatility)
 
 Serialise BackwardFlatVolatility.

--- a/test/unittests/serialisation/rebuild_termstructures.jl
+++ b/test/unittests/serialisation/rebuild_termstructures.jl
@@ -1,5 +1,6 @@
 using DiffFusion
 using Test
+using OrderedCollections
 
 @testset "Extract term structures and rebuild term structure dictionary." begin
 
@@ -8,21 +9,24 @@ using Test
         ts_vector = [
             DiffFusion.flat_forward("yc/flat_forward", 0.01),
             DiffFusion.zero_curve("yc/zero_curve", [ 1.0, 10.0 ], [ 0.02, 0.03 ]),
+            DiffFusion.linear_zero_curve("yc/linear_zero_curve", [ 2.0, 5.0 ], [ 0.02, 0.03 ]),
             DiffFusion.backward_flat_parameter("pa/backward_flat_parameter", [ 0.0 ], [ 1.0 ]),
             DiffFusion.forward_flat_parameter("pa/forward_flat_parameter", [0.0, 2.0], [ 0.10, 0.15] ),
         ]
-        ts_dict = Dict{String,DiffFusion.Termstructure}(((DiffFusion.alias(ts_), ts_) for ts_ in ts_vector))
+        ts_dict = OrderedDict{String,DiffFusion.Termstructure}(((DiffFusion.alias(ts_), ts_) for ts_ in ts_vector))
         #
         (l, v) = DiffFusion.termstructure_values(ts_dict)
         labels = [
             "yc/flat_forward" * delim * "DiffFusion.FlatForward" * delim * "rate",
             "yc/zero_curve" * delim * "DiffFusion.ZeroCurve" * delim * "1.00",
             "yc/zero_curve" * delim * "DiffFusion.ZeroCurve" * delim * "10.00",
+            "yc/linear_zero_curve" * delim * "DiffFusion.LinearZeroCurve" * delim * "2.00",
+            "yc/linear_zero_curve" * delim * "DiffFusion.LinearZeroCurve" * delim * "5.00",
             "pa/backward_flat_parameter" * delim * "DiffFusion.BackwardFlatParameter" * delim * "0.00",
             "pa/forward_flat_parameter" * delim * "DiffFusion.ForwardFlatParameter" * delim * "0.00",
             "pa/forward_flat_parameter" * delim * "DiffFusion.ForwardFlatParameter" * delim * "2.00"
         ]
-        values = [0.01, 0.02, 0.03, 1.0, 0.1, 0.15]
+        values = [0.01, 0.02, 0.03, 0.02, 0.03, 1.0, 0.1, 0.15]
         @test l == labels
         @test v == values
         #
@@ -41,7 +45,7 @@ using Test
             DiffFusion.backward_flat_parameter("pa/backward_flat_parameter", [ 0.0 ], [ 1.0 ]),
             DiffFusion.forward_flat_parameter("pa/forward_flat_parameter", [0.0, 2.0], [ 0.10, 0.15] ),
         ]
-        ts_dict = Dict{String,DiffFusion.Termstructure}(((DiffFusion.alias(ts_), ts_) for ts_ in ts_vector))
+        ts_dict = OrderedDict{String,DiffFusion.Termstructure}(((DiffFusion.alias(ts_), ts_) for ts_ in ts_vector))
         #
         (l, v) = DiffFusion.termstructure_values(ts_dict)
         labels = [

--- a/test/unittests/serialisation/termstructures.jl
+++ b/test/unittests/serialisation/termstructures.jl
@@ -22,6 +22,15 @@ using Test
             "values" => [0.02, 0.03]
         )
         #
+        d = DiffFusion.serialise(DiffFusion.linear_zero_curve("USD", [0.0, 10.0], [0.02, 0.03]))
+        @test d == OrderedDict{String, Any}(
+            "typename" => "DiffFusion.LinearZeroCurve",
+            "constructor" => "LinearZeroCurve",
+            "alias" => "USD",
+            "times" => [0.0, 10.0],
+            "values" => [0.02, 0.03]
+        )
+        #
         times =  [  1.,  2.,  5., 10. ]
         values = [ 50.  60.  70.  80. ;
                    50.  50.  50.  50. ;

--- a/test/unittests/termstructures/rates/rates.jl
+++ b/test/unittests/termstructures/rates/rates.jl
@@ -21,7 +21,7 @@ using Interpolations
         @test ts(2.0) == exp(-0.06)
     end
 
-    @testset "Linear ZeroCurve" begin
+    @testset "ZeroCurve with linear interpolation." begin
         times  = [1.0, 3.0, 6.0, 10.0]
         values = [1.0, 1.0, 2.0,  3.0] .* 1e-2
         ts = DiffFusion.zero_curve("EUR", times, values)
@@ -47,6 +47,34 @@ using Interpolations
         @test DiffFusion.discount(ts2, 2.0) == exp(-2.0*0.01)
         @test DiffFusion.discount(ts2, 4.5) == exp(-4.5*0.015)
         @test DiffFusion.discount(ts2, 10.0) == exp(-10.0*0.03)
+    end
+
+    @testset "LinearZeroCurve." begin
+        #
+        times  = [1.0, 3.0, 6.0, 10.0]
+        values = [1.0, 1.0, 2.0,  3.0] .* 1e-2
+        #
+        @test DiffFusion.alias(DiffFusion.linear_zero_curve("Std", times, values)) == "Std"
+        #
+        ts_tst = DiffFusion.linear_zero_curve(times, values)
+        # test correct interpolation
+        ts_ref = DiffFusion.zero_curve(times, values)
+        _times = 1.0:0.5:10.0
+        for t in _times
+            @test DiffFusion.discount(ts_tst, t) == DiffFusion.discount(ts_ref, t)
+        end
+        # test left flat extrapolation
+        ts_ref = DiffFusion.flat_forward(0.01)
+        _times = 0.0:0.5:1.0
+        for t in _times
+            @test DiffFusion.discount(ts_tst, t) == DiffFusion.discount(ts_ref, t)
+        end
+        # test right flat extrapolation
+        ts_ref = DiffFusion.flat_forward(0.03)
+        _times = 10.0:0.5:11.0
+        for t in _times
+            @test DiffFusion.discount(ts_tst, t) == DiffFusion.discount(ts_ref, t)
+        end
     end
 
     @testset "Test alias-based interpolated zero curves." begin


### PR DESCRIPTION
This PR adds a LinearZeroCurve yield termstructure.

ZeroCurve termstructures use interpolation objects for rate interpolation. This does not work with Zygote for AD sensitivities. The LinearZeroCurve termstructure aims at mitigating the Zygote limitation by manually implementing the linear implementation.