### PR TITLE
Fix Zygote errors with correlation sensitivities

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -118,6 +118,7 @@ module Examples
 end # module
 
 include("chainrules/models.jl")
+include("chainrules/termstructures.jl")
 include("chainrules/simulations.jl")
 
 "List of function names eligible for de-serialisation."

--- a/src/analytics/Valuations.jl
+++ b/src/analytics/Valuations.jl
@@ -212,7 +212,10 @@ function model_price_and_vegas(
     # We need a correlation holder... for simplicity, we assume this is unique in the model
     ch_alias = nothing
     for m in model.models
-        if hasproperty(m, :correlation_holder) && !isnothing(m.correlation_holder)
+        if hasproperty(m, :correlation_holder) &&
+            !isnothing(m.correlation_holder) &&
+            length(m.correlation_holder.correlations) > 0  # avoid Zygote error by differentiating empty dict
+            #
             ch_alias = m.correlation_holder.alias
             break
         end
@@ -299,7 +302,10 @@ function model_price_and_vegas_vector(
     # We need a correlation holder... for simplicity, we assume this is unique in the model
     ch_alias = nothing
     for m in model.models
-        if hasproperty(m, :correlation_holder) && !isnothing(m.correlation_holder)
+        if hasproperty(m, :correlation_holder) &&
+            !isnothing(m.correlation_holder) &&
+            length(m.correlation_holder.correlations) > 0  # avoid Zygote error by differentiating empty dict
+            #
             ch_alias = m.correlation_holder.alias
             break
         end

--- a/src/chainrules/termstructures.jl
+++ b/src/chainrules/termstructures.jl
@@ -1,0 +1,5 @@
+
+# do not differentiate trivial correlation holder setup
+ChainRulesCore.@non_differentiable correlation_holder(alias::String,)
+ChainRulesCore.@non_differentiable correlation_holder(alias::String, sep::String,)
+ChainRulesCore.@non_differentiable correlation_holder(alias::String, sep::String, value_type::DataType)

--- a/src/termstructures/correlation/CorrelationHolder.jl
+++ b/src/termstructures/correlation/CorrelationHolder.jl
@@ -4,7 +4,7 @@
         alias::String
         correlations::Dict{String, ModelValue}
         sep::String
-        value_type::Type
+        value_type::DataType
     end
 
 A container holding correlation values.
@@ -20,7 +20,7 @@ struct CorrelationHolder <: CorrelationTermstructure
     alias::String
     correlations::Dict{String, ModelValue}
     sep::String
-    value_type::Type
+    value_type::DataType
 end
 
 
@@ -28,8 +28,8 @@ end
     correlation_holder(
         alias::String,
         correlations::Dict,
-        sep = "<>",
-        value_type = ModelValue,
+        sep::String = "<>",
+        value_type::DataType = ModelValue,
         )
 
 Create a CorrelationHolder object from dictionary.
@@ -37,8 +37,8 @@ Create a CorrelationHolder object from dictionary.
 function correlation_holder(
     alias::String,
     correlations::Dict,
-    sep = "<>",
-    value_type = ModelValue,
+    sep::String = "<>",
+    value_type::DataType = ModelValue,
     )
     for (key, value) in correlations
         @assert isa(value, value_type)
@@ -51,16 +51,16 @@ end
 """
     correlation_holder(
         alias::String,
-        sep = "<>",
-        value_type = ModelValue,
+        sep::String = "<>",
+        value_type::DataType = ModelValue,
         )
 
 Create an empty CorrelationHolder object.
 """
 function correlation_holder(
     alias::String,
-    sep = "<>",
-    value_type = ModelValue,
+    sep::String = "<>",
+    value_type::DataType = ModelValue,
     )
     return correlation_holder(alias, Dict{String, value_type}(), sep, value_type)
 end


### PR DESCRIPTION
This PR fixes errors with Zygote if differentiating an empty dictionary.
  - avoid trivial correlation sensitivity calculation
  - add type annotations to correlation_holder
  - make correlation_holder non-differentiable