### PR TITLE
Add functions for Year-on-Year coupons with convexity adjustments

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -54,6 +54,7 @@ include("models/futures/MarkovFutureModels.jl")
 
 include("models/asset/AssetVolatility.jl")
 include("models/asset/AssetCalibration.jl")
+include("models/inflation/ConvexityAdjustment.jl")
 
 include("simulations/RandomNumbers.jl")
 include("simulations/Simulation.jl")
@@ -75,6 +76,9 @@ include("payoffs/AssetOptions.jl")
 include("products/Cashflows.jl")
 include("products/AssetOptionFlows.jl")
 include("products/RatesCoupons.jl")
+include("products/RelativeReturnCoupon.jl")
+include("products/RelativeReturnIndexCoupon.jl")
+
 include("products/CashFlowLeg.jl")
 include("products/SwaptionLeg.jl")
 include("products/MtMCashFlowLeg.jl")

--- a/src/models/hybrid/CompositeModel.jl
+++ b/src/models/hybrid/CompositeModel.jl
@@ -257,6 +257,44 @@ end
 
 
 """
+    log_asset_convexity_adjustment(
+        m::CompositeModel,
+        dom_alias::String,
+        for_alias::String,
+        ast_alias::String,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        )
+
+Calculate the YoY convexity adjustment term for OU models.
+
+Returns a scalar quantity.
+"""
+function log_asset_convexity_adjustment(
+    m::CompositeModel,
+    dom_alias::String,
+    for_alias::String,
+    ast_alias::String,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    )
+    return log_asset_convexity_adjustment(
+        m.models[m.model_dict[dom_alias]],
+        m.models[m.model_dict[for_alias]],
+        m.models[m.model_dict[ast_alias]],
+        t,
+        T0,
+        T1,
+        T2,
+    )
+end
+
+
+"""
     state_dependent_Theta(m::CompositeModel)
 
 Return whether Theta requires a state vector input X.

--- a/src/models/inflation/ConvexityAdjustment.jl
+++ b/src/models/inflation/ConvexityAdjustment.jl
@@ -1,0 +1,134 @@
+
+"Wrap function definitions for ν1² to avoid name collisions."
+function _variance_t_T0(
+    dom_model::GaussianHjmModel,
+    for_model::GaussianHjmModel,
+    ch::CorrelationHolder,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    )
+    #
+    Σdx = Sigma_T(dom_model, t, T1)  # T1!
+    Σdz = Sigma_T(dom_model, t, T0)  # T0!
+    Σf = Sigma_T(for_model, t, T0)
+    Gd = G_hjm(dom_model, T1, T2)
+    Gf = G_hjm(for_model, T0, T1)
+    Γ = correlation(ch, vcat(factor_alias(dom_model),factor_alias(for_model)))
+    ΣT(u) = hcat(
+        Gd' * Σdx(u)[1:end-1,:] + Σdz(u)[end:end,:],
+        Gf' * Σf(u)[1:end-1,:],
+    )
+    f(u) = (ΣT(u) * Γ * ΣT(u)')[1,1]  # matrix-matrix multiplications
+    return _scalar_integral(f, t, T0, parameter_grid([dom_model, for_model]))
+end
+
+"Wrap function definitions for ν2² to avoid name collisions."
+function _variance_T0_T1(
+    dom_model::GaussianHjmModel,
+    for_model::GaussianHjmModel,
+    ast_model::LognormalAssetModel,
+    ch::CorrelationHolder,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    )
+    #
+    Σd = Sigma_T(dom_model, t, T1)  # t!
+    Σf = Sigma_T(for_model, T0, T1)
+    Σfd = Sigma_T(ast_model, T0, T1)
+    Gd = G_hjm(dom_model, T1, T2)
+    Γ = correlation(ch, vcat(
+        factor_alias(dom_model),
+        factor_alias(for_model),
+        factor_alias(ast_model),
+        ))
+    ΣT(u) = hcat(
+        Gd' * Σd(u)[1:end-1,:],
+        Σf(u)[end:end,:],
+        - Σfd(u),
+        )
+    f(u) = (ΣT(u) * Γ * ΣT(u)')[1,1]  # matrix-matrix multiplications
+    return _scalar_integral(f, T0, T1, parameter_grid([dom_model, for_model, ast_model]))
+end
+
+"Wrap function definitions for ν3² to avoid name collisions."
+function _variance_T1_T2(
+    dom_model::GaussianHjmModel,
+    ch::CorrelationHolder,
+    T1::ModelTime,
+    T2::ModelTime,
+    )
+    #
+    Σd = Sigma_T(dom_model, T1, T2)
+    Γ = correlation(ch, factor_alias(dom_model))
+    ΣT(u) = Σd(u)[end:end,:]
+    f(u) = (ΣT(u) * Γ * ΣT(u)')[1,1]  # matrix-matrix multiplications
+    return _scalar_integral(f, T1, T2, parameter_grid(dom_model))
+end
+
+
+
+"""
+    log_asset_convexity_adjustment(
+        dom_model::GaussianHjmModel,
+        for_model::GaussianHjmModel,
+        ast_model::LognormalAssetModel,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        )
+
+Calculate convexity adjustment for year-on-year coupons of tradeable assets.
+"""
+function log_asset_convexity_adjustment(
+    dom_model::GaussianHjmModel,
+    for_model::GaussianHjmModel,
+    ast_model::LognormalAssetModel,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    )
+    # common terms
+    yd = func_y(dom_model, t)
+    yf = func_y(for_model, t)
+    ch = dom_model.correlation_holder  # better check that this is the same as for the other models
+    # deterministic components
+    G = G_hjm(dom_model, t, T2)
+    μ1 = 0.5 * G' * yd * G
+    #
+    G1 = G_hjm(for_model, t, T1)
+    G0 = G_hjm(for_model, t, T0)
+    μ2 = 0.5 * (G1' * yf * G1 - G0' * yf * G0)
+    #
+    G0 = G_hjm(dom_model, t, T0)
+    G1 = G_hjm(dom_model, t, T1)
+    μ3 = 0.5 * (G0' * yd * G0 - G1' * yd * G1)
+    #
+    μ4 = -Theta(dom_model, t, T0)[end]  # re-factor to avoid Θx calculation
+    #
+    μ5 = -G_hjm(for_model, T0, T1)' * Theta(for_model, t, T0)[1:end-1]
+    #
+    μ6 = -Theta(for_model, T0, T1)[end]
+    #
+    μ7 = -G_hjm(dom_model, T1, T2)' * Theta(dom_model, t, T1)[1:end-1]
+    #
+    μ8 = -Theta(dom_model, T1, T2)[end]
+    #
+    μ9 = Theta(ast_model, T0, T1)[1]
+    #
+    μ = μ1 + μ2 + μ3 + μ4 + μ5 + μ6 + μ7 + μ8 + μ9
+    # variance components
+    ν1² = _variance_t_T0(dom_model, for_model, ch, t, T0, T1, T2)
+    ν2² = _variance_T0_T1(dom_model, for_model, ast_model, ch, t, T0, T1, T2)
+    ν3² = _variance_T1_T2(dom_model, ch, T1, T2)
+    #
+    ν² = ν1² + ν2² + ν3²
+    #
+    return μ + 0.5 * ν²
+end
+

--- a/src/paths/PathMethods.jl
+++ b/src/paths/PathMethods.jl
@@ -554,3 +554,97 @@ function asset_variance(
         SX,
     )
 end
+
+
+"""
+    asset_convexity_adjustment(
+        p::Path,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        key::String
+        )
+
+Return the convexity adjustment for a YoY asset payoff.
+"""
+function asset_convexity_adjustment(
+    p::Path,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    key::String
+    )
+    #
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key, "-")
+    entry = p.context.assets[context_key]
+    #
+    @assert t  <= T0
+    @assert T0 <= T1
+    @assert T1 <= T2
+    # TODO: specialise for deterministic models
+    @assert !isnothing(entry.domestic_model_alias)
+    @assert !isnothing(entry.foreign_model_alias)
+    @assert !isnothing(entry.asset_model_alias)
+    #
+    ca = log_asset_convexity_adjustment(
+        p.sim.model,
+        entry.domestic_model_alias,
+        entry.foreign_model_alias,
+        entry.asset_model_alias,
+        t,
+        T0,
+        T1,
+        T2,
+    )
+    return exp(ca) * ones(length(p))
+end
+
+
+"""
+    index_convexity_adjustment(
+        p::Path,
+        t::ModelTime,
+        T0::ModelTime,
+        T1::ModelTime,
+        T2::ModelTime,
+        key::String
+        )
+
+Return the convexity adjustment for a YoY index payoff.
+"""
+function index_convexity_adjustment(
+    p::Path,
+    t::ModelTime,
+    T0::ModelTime,
+    T1::ModelTime,
+    T2::ModelTime,
+    key::String
+    )
+    #
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    @assert op in (_empty_context_key,)
+    entry = p.context.forward_indices[context_key]
+    #
+    @assert t  <= T0
+    @assert T0 <= T1
+    @assert T1 <= T2
+    # TODO: specialise for deterministic models
+    @assert !isnothing(entry.domestic_model_alias)
+    @assert !isnothing(entry.foreign_model_alias)
+    @assert !isnothing(entry.asset_model_alias)
+    #
+    ca = log_asset_convexity_adjustment(
+        p.sim.model,
+        entry.domestic_model_alias,
+        entry.foreign_model_alias,
+        entry.asset_model_alias,
+        t,
+        T0,
+        T1,
+        T2,
+    )
+    return exp(ca) * ones(length(p))
+end

--- a/src/payoffs/Leafs.jl
+++ b/src/payoffs/Leafs.jl
@@ -252,3 +252,143 @@ Formatted (and shortened) output for deterministic payoff.
 """
 string(p::ScalarValue) = @sprintf("%.4f", p.value)
 
+"""
+    struct AssetConvexityAdjustment <: Leaf
+        obs_time::ModelTime
+        first_time::ModelTime
+        second_time::ModelTime
+        pay_time::ModelTime
+        key::String
+    end
+
+Convexity adjustment factor for YoY asset payoffs.
+"""
+struct AssetConvexityAdjustment <: Leaf
+    obs_time::ModelTime
+    first_time::ModelTime
+    second_time::ModelTime
+    pay_time::ModelTime
+    key::String
+end
+
+"""
+    at(p::AssetConvexityAdjustment, path::AbstractPath)
+
+Derive the YoY payoff convexity adjustment at a given path.
+"""
+at(p::AssetConvexityAdjustment, path::AbstractPath) = asset_convexity_adjustment(path, p.obs_time, p.first_time, p.second_time, p.pay_time, p.key)
+
+"""
+    string(p::AssetConvexityAdjustment)
+
+Formatted (and shortened) output for AssetConvexityAdjustment payoff.
+"""
+string(p::AssetConvexityAdjustment) = @sprintf("Exp{CA(%s, %.2f, %.2f, %.2f, %.2f)}", p.key, p.obs_time, p.first_time, p.second_time, p.pay_time)
+
+
+"""
+    struct ForwardIndex <: Leaf
+        obs_time::ModelTime
+        maturity_time::ModelTime
+        key::String
+    end
+
+Expectation E_t^T[S_T] of a tradeable asset.
+
+This is used in particular for inflation modelling.
+"""
+struct ForwardIndex <: Leaf
+    obs_time::ModelTime
+    maturity_time::ModelTime
+    key::String
+end
+
+"""
+    at(p::ForwardIndex, path::AbstractPath)
+
+Derive forward index value at a given path.
+"""
+at(p::ForwardIndex, path::AbstractPath) = forward_index(path, p.obs_time, p.maturity_time, p.key)
+
+"""
+    string(p::ForwardIndex)
+
+Formatted (and shortened) output for ForwardIndex payoff.
+"""
+string(p::ForwardIndex) = begin
+    if p.obs_time == p.maturity_time
+        return @sprintf("I(%s, %.2f)", p.key, p.obs_time)
+    end
+    return @sprintf("I(%s, %.2f, %.2f)", p.key, p.obs_time, p.maturity_time)
+end
+
+
+"""
+    struct IndexConvexityAdjustment <: Leaf
+        obs_time::ModelTime
+        first_time::ModelTime
+        second_time::ModelTime
+        pay_time::ModelTime
+        key::String
+    end
+
+Convexity adjustment factor for YoY index payoffs.
+"""
+struct IndexConvexityAdjustment <: Leaf
+    obs_time::ModelTime
+    first_time::ModelTime
+    second_time::ModelTime
+    pay_time::ModelTime
+    key::String
+end
+
+"""
+    at(p::IndexConvexityAdjustment, path::AbstractPath)
+
+Derive the YoY payoff convexity adjustment at a given path.
+"""
+at(p::IndexConvexityAdjustment, path::AbstractPath) = index_convexity_adjustment(path, p.obs_time, p.first_time, p.second_time, p.pay_time, p.key)
+
+"""
+    string(p::IndexConvexityAdjustment)
+
+Formatted (and shortened) output for IndexConvexityAdjustment payoff.
+"""
+string(p::IndexConvexityAdjustment) = @sprintf("Exp{CA(%s, %.2f, %.2f, %.2f, %.2f)}", p.key, p.obs_time, p.first_time, p.second_time, p.pay_time)
+
+
+"""
+    struct FutureIndex <: Leaf
+        obs_time::ModelTime
+        maturity_time::ModelTime
+        key::String
+    end
+
+Risk-neutral expectation E_t^T[S_T] of a price index.
+
+This is used in particular for Future modelling.
+"""
+struct FutureIndex <: Leaf
+    obs_time::ModelTime
+    maturity_time::ModelTime
+    key::String
+end
+
+"""
+    at(p::FutureIndex, path::AbstractPath)
+
+Derive forward index value at a given path.
+"""
+at(p::FutureIndex, path::AbstractPath) = future_index(path, p.obs_time, p.maturity_time, p.key)
+
+"""
+    string(p::FutureIndex)
+
+Formatted (and shortened) output for FutureIndex payoff.
+"""
+string(p::FutureIndex) = begin
+    if p.obs_time == p.maturity_time
+        return @sprintf("F(%s, %.2f)", p.key, p.obs_time)
+    end
+    return @sprintf("F(%s, %.2f, %.2f)", p.key, p.obs_time, p.maturity_time)
+end

--- a/src/products/RelativeReturnCoupon.jl
+++ b/src/products/RelativeReturnCoupon.jl
@@ -1,0 +1,83 @@
+
+
+"""
+    struct RelativeReturnCoupon <: Coupon
+        first_time::ModelTime
+        second_time::ModelTime
+        pay_time::ModelTime
+        year_fraction::ModelValue
+        asset_key::String
+        curve_key_dom::String
+        curve_key_for::String
+    end
+
+A `RelativeReturnCoupon` pays a coupon with rate (S2/S1 - 1) / dT. Here,
+S1 and S2 are spot asset prices.
+
+Such a coupon is typical for year-on-year type instruments.
+"""
+struct RelativeReturnCoupon <: Coupon
+    first_time::ModelTime
+    second_time::ModelTime
+    pay_time::ModelTime
+    year_fraction::ModelValue
+    asset_key::String
+    curve_key_dom::String
+    curve_key_for::String
+end
+
+"""
+    year_fraction(cf::RelativeReturnCoupon)
+
+Return RelativeReturnCoupon year_fraction.
+"""
+year_fraction(cf::RelativeReturnCoupon) = cf.year_fraction
+
+"""
+    coupon_rate(cf::RelativeReturnCoupon)
+
+Return RelativeReturnCoupon rate.
+"""
+function coupon_rate(cf::RelativeReturnCoupon)
+    S1 = Asset(cf.first_time, cf.asset_key)
+    S2 = Asset(cf.second_time, cf.asset_key)
+    return (S2 / S1 - 1.0) / cf.year_fraction
+end
+
+"""
+    forward_rate(cf::RelativeReturnCoupon, obs_time::ModelTime)
+
+Return RelativeReturnCoupon forward rate.
+"""
+function forward_rate(cf::RelativeReturnCoupon, obs_time::ModelTime)
+    S1 = Asset(min(obs_time, cf.first_time), cf.asset_key)
+    if obs_time < cf.first_time
+        df_dom = ZeroBond(obs_time, cf.first_time, cf.curve_key_dom)
+        df_for = ZeroBond(obs_time, cf.first_time, cf.curve_key_for)
+        S1 = S1 * df_for / df_dom
+    end
+    S2 = Asset(min(obs_time, cf.second_time), cf.asset_key)
+    if obs_time < cf.second_time
+        df_dom = ZeroBond(obs_time, cf.second_time, cf.curve_key_dom)
+        df_for = ZeroBond(obs_time, cf.second_time, cf.curve_key_for)
+        S2 = S2 * df_for / df_dom
+    end
+    S2_over_S1 = S2 / S1
+    CA = nothing
+    if (obs_time < cf.second_time) && (cf.first_time < cf.second_time)
+        if obs_time < cf.first_time
+            # full YoY CA
+            CA = AssetConvexityAdjustment(obs_time, cf.first_time, cf.second_time, cf.pay_time, cf.asset_key)
+        else
+            if cf.second_time < cf.pay_time
+                # payment delay CA
+                CA = AssetConvexityAdjustment(obs_time, obs_time, cf.second_time, cf.pay_time, cf.asset_key)
+            end    
+        end
+    end
+    if !isnothing(CA)
+        S2_over_S1 = S2_over_S1 * CA
+    end
+    return (S2_over_S1 - 1.0) / cf.year_fraction
+end
+

--- a/src/products/RelativeReturnIndexCoupon.jl
+++ b/src/products/RelativeReturnIndexCoupon.jl
@@ -1,0 +1,68 @@
+
+"""
+    struct RelativeReturnIndexCoupon <: Coupon
+        first_time::ModelTime
+        second_time::ModelTime
+        pay_time::ModelTime
+        year_fraction::ModelValue
+        forward_index_key::String
+    end
+
+A `RelativeReturnIndexCoupon` pays a coupon with rate (I2/I1 - 1) / dT. Here,
+I1 and I2 are spot (index) prices for which a forward index curve is available.
+
+Such a coupon is typical for year-on-year type instruments.
+"""
+struct RelativeReturnIndexCoupon <: Coupon
+    first_time::ModelTime
+    second_time::ModelTime
+    pay_time::ModelTime
+    year_fraction::ModelValue
+    forward_index_key::String
+end
+
+"""
+    year_fraction(cf::RelativeReturnIndexCoupon)
+
+Return RelativeReturnIndexCoupon year_fraction.
+"""
+year_fraction(cf::RelativeReturnIndexCoupon) = cf.year_fraction
+
+"""
+    coupon_rate(cf::RelativeReturnIndexCoupon)
+
+Return RelativeReturnIndexCoupon rate.
+"""
+function coupon_rate(cf::RelativeReturnIndexCoupon)
+    I1 = ForwardIndex(cf.first_time, cf.first_time, cf.forward_index_key)
+    I2 = ForwardIndex(cf.second_time, cf.second_time, cf.forward_index_key)
+    return (I2 / I1 - 1.0) / cf.year_fraction
+end
+
+"""
+    forward_rate(cf::RelativeReturnIndexCoupon, obs_time::ModelTime)
+
+Return RelativeReturnIndexCoupon forward rate.
+"""
+function forward_rate(cf::RelativeReturnIndexCoupon, obs_time::ModelTime)
+    I1 = ForwardIndex(min(obs_time, cf.first_time), cf.first_time, cf.forward_index_key)
+    I2 = ForwardIndex(min(obs_time, cf.second_time), cf.second_time, cf.forward_index_key)
+    I2_over_I1 = I2 / I1
+    CA = nothing
+    if (obs_time < cf.second_time) && (cf.first_time < cf.second_time)
+        if obs_time < cf.first_time
+            # full YoY CA
+            CA = IndexConvexityAdjustment(obs_time, cf.first_time, cf.second_time, cf.pay_time, cf.forward_index_key)
+        else
+            if cf.second_time < cf.pay_time
+                # payment delay CA
+                CA = IndexConvexityAdjustment(obs_time, obs_time, cf.second_time, cf.pay_time, cf.forward_index_key)
+            end    
+        end
+    end
+    if !isnothing(CA)
+        I2_over_I1 = I2_over_I1 * CA
+    end
+    return (I2_over_I1 - 1.0) / cf.year_fraction
+end
+

--- a/test/unittests/models/hybrid/simple_model.jl
+++ b/test/unittests/models/hybrid/simple_model.jl
@@ -143,6 +143,8 @@ using Test
         @test DiffFusion.asset_variance(m, nothing, "USD", "EUR", 1.0, 8.0, SX) == DiffFusion.asset_variance(nothing, hjm_model_dom, hjm_model_for, ch, 1.0, 8.0)
         @test DiffFusion.asset_variance(m, nothing, nothing, nothing, 1.0, 8.0, SX) == 0.0
         #
+        @test DiffFusion.log_asset_convexity_adjustment(m, "USD", "EUR", "EUR-USD", 5.0, 10.0, 15.0, 20.0) == DiffFusion.log_asset_convexity_adjustment(hjm_model_dom, hjm_model_for, asset_model, 5.0, 10.0, 15.0, 20.0)
+        #
         @test_throws KeyError DiffFusion.log_asset(m, "WrongAlias", 1.0, SX)
         @test_throws KeyError DiffFusion.log_bank_account(m, "WrongAlias", 1.0, SX)
         @test_throws KeyError DiffFusion.log_zero_bond(m, "WrongAlias", 4.0, 8.0, SX)

--- a/test/unittests/models/inflation/convexity_adjustment.jl
+++ b/test/unittests/models/inflation/convexity_adjustment.jl
@@ -1,0 +1,108 @@
+
+using DiffFusion
+using Test
+
+@testset "Year-on-year convexity adjustment." begin
+
+    ch_one = DiffFusion.correlation_holder("One")
+    ch_full = DiffFusion.correlation_holder("Full")
+    #
+    DiffFusion.set_correlation!(ch_full, "USD_f_1", "USD_f_2", 0.8)
+    DiffFusion.set_correlation!(ch_full, "USD_f_2", "USD_f_3", 0.8)
+    DiffFusion.set_correlation!(ch_full, "USD_f_1", "USD_f_3", 0.5)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR_f_1", "EUR_f_2", 0.50)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "EUR_f_1", -0.30)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "EUR_f_2", -0.30)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "USD_f_1", -0.20)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "USD_f_2", -0.20)
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "USD_f_3", -0.20)
+    #
+    DiffFusion.set_correlation!(ch_full, "USD_f_1", "EUR_f_1", 0.30)
+    DiffFusion.set_correlation!(ch_full, "USD_f_2", "EUR_f_2", 0.30)
+    #
+    DiffFusion.set_correlation!(ch_full, "EUR-USD_x", "SXE50_x", 0.70)
+    
+    function setup_models(
+        ch;
+        dom_vol_scaling = 1.0,
+        for_vol_scaling = 1.0,
+        ast_vol_scaling = 1.0,
+        )
+        sigma_fx = DiffFusion.flat_volatility("EUR-USD", 0.15 * ast_vol_scaling)
+        fx_model = DiffFusion.lognormal_asset_model("EUR-USD", sigma_fx, ch, nothing)
+    
+        sigma_fx = DiffFusion.flat_volatility("SXE50", 0.10)
+        eq_model = DiffFusion.lognormal_asset_model("SXE50-EUR", sigma_fx, ch, fx_model)
+    
+        delta_dom = DiffFusion.flat_parameter([ 1., 7., 15. ])
+        chi_dom = DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ])
+        times_dom =  [ 0. ]
+        values_dom = [ 50. 60. 70. ]' * 1.0e-4 * dom_vol_scaling
+        sigma_f_dom = DiffFusion.backward_flat_volatility("USD",times_dom,values_dom)
+        hjm_model_dom = DiffFusion.gaussian_hjm_model("USD",delta_dom,chi_dom,sigma_f_dom,ch,nothing)
+    
+        delta_for = DiffFusion.flat_parameter([ 1., 10. ])
+        chi_for = DiffFusion.flat_parameter([ 0.01, 0.15 ])
+        times_for =  [ 0. ]
+        values_for = [ 80. 90. ]' * 1.0e-4 * for_vol_scaling
+        sigma_f_for = DiffFusion.backward_flat_volatility("EUR",times_for,values_for)
+        hjm_model_for = DiffFusion.gaussian_hjm_model("EUR",delta_for,chi_for,sigma_f_for,ch,fx_model)
+    
+        return [ hjm_model_dom, fx_model, hjm_model_for, eq_model ]
+    end
+    
+    @testset "Boundary cases per times." begin
+        ch = ch_full
+        models = setup_models(ch)
+        #
+        ca(t, T0, T1, T2) = DiffFusion.log_asset_convexity_adjustment(
+            models[1],
+            models[3],
+            models[2],
+            t, T0, T1, T2,
+            )
+        # T0 == T1, deterministic payoff
+        t = 10.0
+        T = [ 10.0, 12.0, 14.0, 16.0, 18.0, 20.0 ]
+        T2 = 20.0
+        for (T0, T1) in zip(T, T)
+            @test isapprox(ca(t, T0, T1, T2), 0.0, atol=1.0e-16)
+            # display(ca(t, T0, T1, T2))
+        end
+        # t == T0, T1 == T2, forward index w/o payment delay
+        t = 10.0
+        T0 = 10.0
+        T = [ 10.0, 12.0, 14.0, 16.0, 18.0, 20.0 ]
+        for (T1, T2) in zip(T, T)
+            @test isapprox(ca(t, T0, T1, T2), 0.0, atol=1.2e-16)
+            # display(ca(t, T0, T1, T2))
+        end
+    end
+
+    @testset "Boundary cases deterministic rates." begin
+        ch = ch_full
+        models = setup_models(
+            ch,
+            dom_vol_scaling = 0.0,
+            for_vol_scaling = 0.0,
+            )
+        #
+        ca(t, T0, T1, T2) = DiffFusion.log_asset_convexity_adjustment(
+            models[1],
+            models[3],
+            models[2],
+            t, T0, T1, T2,
+            )
+        # T0 == T1, deterministic payoff
+        t = 10.0
+        T0 = 13.0
+        T1 = 16.0
+        T2 = 20.0
+        @test ca(t, T0, T1, T2) == 0.0
+        # display(ca(t, T0, T1, T2))
+    end
+
+end

--- a/test/unittests/models/inflation/inflation.jl
+++ b/test/unittests/models/inflation/inflation.jl
@@ -3,6 +3,5 @@ using Test
 
 @testset "Inflation index models." begin
 
-    # Add tests here.
-
+    include("convexity_adjustment.jl")
 end

--- a/test/unittests/paths/path.jl
+++ b/test/unittests/paths/path.jl
@@ -336,6 +336,14 @@ end
         v1 = DiffFusion.asset_variance(p, 1.0, 4.0, "SXE50")
         v2 = DiffFusion.asset_variance(p.sim.model, "SXE50-EUR", "EUR", nothing, 1.0, 4.0, SX)
         @test v1 == ones(5) * v2
+        #
+        models = sim.model.models
+        ca_path = DiffFusion.asset_convexity_adjustment(p, 5.0, 10.0, 15.0, 20.0, "EUR-USD")
+        log_ca = DiffFusion.log_asset_convexity_adjustment(models[1], models[3], models[2], 5.0, 10.0, 15.0, 20.0)
+        @test ca_path == exp(log_ca) * ones(5)
+        #
+        ca_path_index = DiffFusion.index_convexity_adjustment(p, 5.0, 10.0, 15.0, 20.0, "HICP")
+        @test isapprox(ca_path_index, ca_path, atol=5.0e-15)
     end
 
     @testset "Deterministic modelling." begin

--- a/test/unittests/payoffs/nodes_and_leafs.jl
+++ b/test/unittests/payoffs/nodes_and_leafs.jl
@@ -11,6 +11,23 @@ using Test
     DiffFusion.asset(p::ConstantPath, t::DiffFusion.ModelTime, key::String) = 5.0 * ones(5)
     DiffFusion.forward_asset(p::ConstantPath, t::DiffFusion.ModelTime, T::DiffFusion.ModelTime, key::String) = 6.0 * ones(5)
     DiffFusion.fixing(p::ConstantPath, t::DiffFusion.ModelTime, key::String) = 6.0 * ones(5)
+    DiffFusion.asset_convexity_adjustment(
+        p::ConstantPath,
+        t::DiffFusion.ModelTime,
+        T0::DiffFusion.ModelTime,
+        T1::DiffFusion.ModelTime,
+        T2::DiffFusion.ModelTime,
+        key::String) = ones(5)
+    DiffFusion.forward_index(p::ConstantPath, t::DiffFusion.ModelTime, T::DiffFusion.ModelTime, key::String) = 2.0 * ones(5)
+    DiffFusion.index_convexity_adjustment(
+        p::ConstantPath,
+        t::DiffFusion.ModelTime,
+        T0::DiffFusion.ModelTime,
+        T1::DiffFusion.ModelTime,
+        T2::DiffFusion.ModelTime,
+        key::String) = ones(5)
+        DiffFusion.future_index(p::ConstantPath, t::DiffFusion.ModelTime, T::DiffFusion.ModelTime, key::String) = 3.0 * ones(5)
+    #
     DiffFusion.length(p::ConstantPath) = 5
 
     @testset "Leaf payoffs" begin
@@ -72,6 +89,36 @@ using Test
         @test p(path) == 3.5
         @test string(p) == "3.5000"
         #
+        p = DiffFusion.AssetConvexityAdjustment(5.0, 10.0, 15.0, 20.0, "EUR-USD")
+        @test DiffFusion.obs_time(p) == 5.0
+        @test DiffFusion.obs_times(p) == Set(5.0)
+        @test DiffFusion.at(p, path) == ones(5)
+        @test p(path) == ones(5)
+        @test string(p) == "Exp{CA(EUR-USD, 5.00, 10.00, 15.00, 20.00)}"
+        #
+        p = DiffFusion.ForwardIndex(5.0, 10.0, "EUHICP")
+        @test DiffFusion.obs_time(p) == 5.0
+        @test DiffFusion.obs_times(p) == Set(5.0)
+        @test DiffFusion.at(p, path) == 2. * ones(5)
+        @test p(path) == 2. * ones(5)
+        @test string(p) == "I(EUHICP, 5.00, 10.00)"
+        @test string(DiffFusion.ForwardIndex(5.0, 5.0, "EUHICP")) == "I(EUHICP, 5.00)"
+        #
+        p = DiffFusion.IndexConvexityAdjustment(5.0, 10.0, 15.0, 20.0, "EUR-USD")
+        @test DiffFusion.obs_time(p) == 5.0
+        @test DiffFusion.obs_times(p) == Set(5.0)
+        @test DiffFusion.at(p, path) == ones(5)
+        @test p(path) == ones(5)
+        @test string(p) == "Exp{CA(EUR-USD, 5.00, 10.00, 15.00, 20.00)}"
+        #
+        p = DiffFusion.FutureIndex(5.0, 10.0, "NIK")
+        @test DiffFusion.obs_time(p) == 5.0
+        @test DiffFusion.obs_times(p) == Set(5.0)
+        @test DiffFusion.at(p, path) == 3. * ones(5)
+        @test p(path) == 3. * ones(5)
+        @test string(p) == "F(NIK, 5.00, 10.00)"
+        @test string(DiffFusion.FutureIndex(5.0, 5.0, "NIK")) == "F(NIK, 5.00)"
+
     end
 
     @testset "Unary nodes" begin

--- a/test/unittests/products/products.jl
+++ b/test/unittests/products/products.jl
@@ -6,6 +6,8 @@ using Test
     include("cashflows.jl")
     include("asset_option_flows.jl")
     include("rates_coupons.jl")
+    include("relative_return_coupons.jl")
+
     include("cashflow_leg.jl")
     include("mtm_cashflow_leg.jl")
     include("cash_and_asset_legs.jl")

--- a/test/unittests/products/relative_return_coupons.jl
+++ b/test/unittests/products/relative_return_coupons.jl
@@ -1,0 +1,86 @@
+
+using DiffFusion
+
+using Test
+
+@testset "Relative return coupons." begin
+
+    @testset "Non-trivial year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnCoupon(3.0, 5.0, 9.0, 2.0, "EUHICP", "EUR", "EURHICP-RR")
+        @test DiffFusion.pay_time(C) == 9.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.Asset(5.0, "EUHICP") / DiffFusion.Asset(3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "((((S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 5.00) / P(EUR, 0.00, 5.00)) / (S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 3.00) / P(EUR, 0.00, 3.00))) * Exp{CA(EUHICP, 0.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "((((S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 5.00) / P(EUR, 1.00, 5.00)) / (S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 3.00) / P(EUR, 1.00, 3.00))) * Exp{CA(EUHICP, 1.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "((((S(EUHICP, 3.00) * P(EURHICP-RR, 3.00, 5.00) / P(EUR, 3.00, 5.00)) / S(EUHICP, 3.00)) * Exp{CA(EUHICP, 3.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "((((S(EUHICP, 4.00) * P(EURHICP-RR, 4.00, 5.00) / P(EUR, 4.00, 5.00)) / S(EUHICP, 3.00)) * Exp{CA(EUHICP, 4.00, 4.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((S(EUHICP, 5.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((S(EUHICP, 5.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+    @testset "No payment delay year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnCoupon(3.0, 5.0, 5.0, 2.0, "EUHICP", "EUR", "EURHICP-RR")
+        @test DiffFusion.pay_time(C) == 5.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.Asset(5.0, "EUHICP") / DiffFusion.Asset(3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "((((S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 5.00) / P(EUR, 0.00, 5.00)) / (S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 3.00) / P(EUR, 0.00, 3.00))) * Exp{CA(EUHICP, 0.00, 3.00, 5.00, 5.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "((((S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 5.00) / P(EUR, 1.00, 5.00)) / (S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 3.00) / P(EUR, 1.00, 3.00))) * Exp{CA(EUHICP, 1.00, 3.00, 5.00, 5.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "((((S(EUHICP, 3.00) * P(EURHICP-RR, 3.00, 5.00) / P(EUR, 3.00, 5.00)) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "((((S(EUHICP, 4.00) * P(EURHICP-RR, 4.00, 5.00) / P(EUR, 4.00, 5.00)) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((S(EUHICP, 5.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((S(EUHICP, 5.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+    @testset "Trivial year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnCoupon(3.0, 3.0, 5.0, 2.0, "EUHICP", "EUR", "EURHICP-RR")
+        @test DiffFusion.pay_time(C) == 5.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.Asset(3.0, "EUHICP") / DiffFusion.Asset(3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "((((S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 3.00) / P(EUR, 0.00, 3.00)) / (S(EUHICP, 0.00) * P(EURHICP-RR, 0.00, 3.00) / P(EUR, 0.00, 3.00))) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "((((S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 3.00) / P(EUR, 1.00, 3.00)) / (S(EUHICP, 1.00) * P(EURHICP-RR, 1.00, 3.00) / P(EUR, 1.00, 3.00))) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "(((S(EUHICP, 3.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "(((S(EUHICP, 3.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((S(EUHICP, 3.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((S(EUHICP, 3.00) / S(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+    @testset "Non-trivial year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnIndexCoupon(3.0, 5.0, 9.0, 2.0, "EUHICP")
+        @test DiffFusion.pay_time(C) == 9.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.ForwardIndex(5.0, 5.0, "EUHICP") / DiffFusion.ForwardIndex(3.0, 3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "(((I(EUHICP, 0.00, 5.00) / I(EUHICP, 0.00, 3.00)) * Exp{CA(EUHICP, 0.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "(((I(EUHICP, 1.00, 5.00) / I(EUHICP, 1.00, 3.00)) * Exp{CA(EUHICP, 1.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "(((I(EUHICP, 3.00, 5.00) / I(EUHICP, 3.00)) * Exp{CA(EUHICP, 3.00, 3.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "(((I(EUHICP, 4.00, 5.00) / I(EUHICP, 3.00)) * Exp{CA(EUHICP, 4.00, 4.00, 5.00, 9.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((I(EUHICP, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((I(EUHICP, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+    @testset "No payment delay year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnIndexCoupon(3.0, 5.0, 5.0, 2.0, "EUHICP")
+        @test DiffFusion.pay_time(C) == 5.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.ForwardIndex(5.0, 5.0, "EUHICP") / DiffFusion.ForwardIndex(3.0, 3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "(((I(EUHICP, 0.00, 5.00) / I(EUHICP, 0.00, 3.00)) * Exp{CA(EUHICP, 0.00, 3.00, 5.00, 5.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "(((I(EUHICP, 1.00, 5.00) / I(EUHICP, 1.00, 3.00)) * Exp{CA(EUHICP, 1.00, 3.00, 5.00, 5.00)} - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "(((I(EUHICP, 3.00, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "(((I(EUHICP, 4.00, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((I(EUHICP, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((I(EUHICP, 5.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+    @testset "Trivial year-on-Year coupon. " begin
+        C = DiffFusion.RelativeReturnIndexCoupon(3.0, 3.0, 5.0, 2.0, "EUHICP")
+        @test DiffFusion.pay_time(C) == 5.0
+        @test DiffFusion.year_fraction(C) == 2.0
+        @test DiffFusion.coupon_rate(C) === (DiffFusion.ForwardIndex(3.0, 3.0, "EUHICP") / DiffFusion.ForwardIndex(3.0, 3.0, "EUHICP") - 1.0) / 2.0
+        @test string(DiffFusion.forward_rate(C, 0.0)) == "(((I(EUHICP, 0.00, 3.00) / I(EUHICP, 0.00, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 1.0)) == "(((I(EUHICP, 1.00, 3.00) / I(EUHICP, 1.00, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 3.0)) == "(((I(EUHICP, 3.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 4.0)) == "(((I(EUHICP, 3.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 5.0)) == "(((I(EUHICP, 3.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+        @test string(DiffFusion.forward_rate(C, 9.0)) == "(((I(EUHICP, 3.00) / I(EUHICP, 3.00)) - 1.0000) / 2.0000)"
+    end
+
+end


### PR DESCRIPTION
This PR adds methods for simulating YoY coupons with resulting convexity adjustments.

  - log_asset_convexity_adjustment model functions
  - asset_convexity_adjustment path function
  - index_convexity_adjustment path function
  - AssetConvexityAdjustment payoff
  - IndexConvexityAdjustment payoff
  - ForwardIndex, FutureIndex payoff
  - RelativeReturnCoupon cash flow
  - RelativeReturnIndexCoupon cash flow

Primary use case are inflation-linked products. Methodology can also be applied to FX- or equity-linked products. 