### PR TITLE
Re-factor numeraire curve key handling

### DIFF
--- a/src/examples/Products.jl
+++ b/src/examples/Products.jl
@@ -357,6 +357,7 @@ function random_bermudan(
     last_expiry_time = max(first_expiry_time, maturity_time - bermudan_time)
     exercise_times = first_expiry_time:bermudan_time:last_expiry_time
     swpt_long_short = rand(-1:2:1)
+    numeraire_curve_key = example["config/instruments"]["discount_curve_key"]
     #
     berm = DiffFusion.bermudan_swaption_leg(
         swaption_alias,
@@ -364,6 +365,7 @@ function random_bermudan(
         swap[2],
         exercise_times,
         swpt_long_short,
+        numeraire_curve_key,
     )
     return [ berm ]
 end

--- a/src/examples/yaml/g3_1factor_flat.yaml
+++ b/src/examples/yaml/g3_1factor_flat.yaml
@@ -9,6 +9,7 @@
     model_alias: "md/USD"
     termstructure_alias:
       <empty_key> : "yc/USD:SOFR"
+      SOFR : "yc/USD:SOFR"
   rates:
     USD:
       typename: "DiffFusion.RatesEntry"
@@ -363,7 +364,7 @@
     step: 1.0
     stop: 10.0
   with_progress_bar: true
-  discount_curve_key: ""
+  discount_curve_key: "USD:SOFR"
   swap_types:
     - USD
     - EUR

--- a/src/precompile/scenarios.jl
+++ b/src/precompile/scenarios.jl
@@ -19,7 +19,7 @@ legs = vcat(
     Examples.random_bermudan(example_, "SONIA_SWPN"),
 )
 
-scens = scenarios(legs, sim.times, path_, "", with_progress_bar=false)
+scens = scenarios(legs, sim.times, path_, "USD", with_progress_bar=false)
 scens = aggregate(scens)
 
 join_scenarios([scens, scens,])

--- a/src/products/BermudanSwaptionLeg.jl
+++ b/src/products/BermudanSwaptionLeg.jl
@@ -426,7 +426,8 @@ end
         float_leg::DeterministicCashFlowLeg,
         exercise_times::AbstractVector,
         option_long_short::ModelValue,
-        regression_on_exercise_trigger = false,
+        numeraire_curve_key::String,
+        regression_on_exercise_trigger = true,
         )
 
 Create a `BermudanSwaptionLeg` using simplified interface.
@@ -442,11 +443,11 @@ function bermudan_swaption_leg(
     float_leg::DeterministicCashFlowLeg,
     exercise_times::AbstractVector,
     option_long_short::ModelValue,
+    numeraire_curve_key::String,
     regression_on_exercise_trigger = true,
     )
     #
     bermudan_exercises = make_bermudan_exercises(fixed_leg, float_leg, exercise_times)
-    numeraire_curve_key = "" # default discounting
     #
     curve_key = float_leg.cashflows[begin].curve_key
     maturity_time = fixed_leg.cashflows[end].pay_time

--- a/test/componenttests/scenarios/asset_options.jl
+++ b/test/componenttests/scenarios/asset_options.jl
@@ -44,7 +44,7 @@ using UnicodePlots
             [ 1.0, ],
             "USD"
         )
-        scens = DiffFusion.scenarios([call_leg, put_leg], times, path, "")
+        scens = DiffFusion.scenarios([call_leg, put_leg], times, path, "USD")
         mv = DiffFusion.aggregate(scens, true, false)
         #
         plot_scens(mv, "EUR-USD option mv")

--- a/test/componenttests/scenarios/bermudan_swaption.jl
+++ b/test/componenttests/scenarios/bermudan_swaption.jl
@@ -53,7 +53,7 @@ using Test
             "berm",
             [ exercise_1, exercise_2, exercise_3,],
             1.0, # long option
-            "", # default discounting (curve key)
+            "EUR", # default discounting (curve key)
             make_regression_variables,
             nothing, # path
             nothing, # make_regression
@@ -98,7 +98,7 @@ using Test
 
         DiffFusion.reset_regression!(berm, path, make_regression)
         #
-        scens = DiffFusion.scenarios([berm], times, path, "")
+        scens = DiffFusion.scenarios([berm], times, path, "EUR")
         println(size(scens.X))
         println(size(sim.X))
         #
@@ -118,14 +118,15 @@ using Test
             float_leg,
             [ 1.0, 2.0, 3.0 ],
             1.0,
+            "EUR"
         )
         DiffFusion.reset_regression!(berm2, path, make_regression)
-        scens2 = DiffFusion.scenarios([berm2], times, path, "")
+        scens2 = DiffFusion.scenarios([berm2], times, path, "EUR")
         @test maximum(abs.(scens.X - scens2.X)) == 0.0
 
         # different regression method
         DiffFusion.reset_regression!(berm2, path, nothing)
-        scens3 = DiffFusion.scenarios([berm2], times, path, "")
+        scens3 = DiffFusion.scenarios([berm2], times, path, "EUR")
         #
         scens2_agg = DiffFusion.aggregate(scens2)
         scens3_agg = DiffFusion.aggregate(scens3)

--- a/test/componenttests/scenarios/rates_option.jl
+++ b/test/componenttests/scenarios/rates_option.jl
@@ -164,7 +164,7 @@ using UnicodePlots
             for (s, e) in zip(fixed_times[1:end-1], fixed_times[2:end])
         ]
         lib_leg = DiffFusion.SwaptionLeg("lib/5x10", start_time, start_time, lib_float_coupons, fixed_coupons, 1.0, "EUR:OIS", DiffFusion.SwaptionPhysicalSettlement, 100.0)
-        scens = DiffFusion.scenarios([lib_leg, ], times, path, "")
+        scens = DiffFusion.scenarios([lib_leg, ], times, path, "EUR")
         mv = DiffFusion.aggregate(scens)
         ee = DiffFusion.expected_exposure(scens)
         plot_scens(mv, "market value - Libor swaption")
@@ -186,7 +186,7 @@ using UnicodePlots
             for (s, e) in zip(fixed_times[1:end-1], fixed_times[2:end])
         ]
         lib_leg = DiffFusion.SwaptionLeg("ois/5x10", start_time, start_time, lib_float_coupons, fixed_coupons, 1.0, "EUR:OIS", DiffFusion.SwaptionPhysicalSettlement, 100.0)
-        scens = DiffFusion.scenarios([lib_leg, ], times, path, "")
+        scens = DiffFusion.scenarios([lib_leg, ], times, path, "EUR")
         mv = DiffFusion.aggregate(scens)
         ee = DiffFusion.expected_exposure(scens)
         plot_scens(mv, "market value - OIS swaption")

--- a/test/componenttests/scenarios/scenarios.jl
+++ b/test/componenttests/scenarios/scenarios.jl
@@ -308,12 +308,12 @@ using YAML
         usd_swap_1 = [ usd_swap[1], usd_swap[1], usd_swap[1], usd_swap[2]]  # make the swap more at par
         usd_swap_2 = [ usd_swap[1], usd_swap[1], usd_swap[1], usd_swap[1], usd_swap[2]]  # make the swap more at par
         obs_times = 0.0:1.0/12:7.0
-        scens_1 = DiffFusion.scenarios(usd_swap_1, obs_times, path, "")
+        scens_1 = DiffFusion.scenarios(usd_swap_1, obs_times, path, "USD")
         plot_swap(scens_1, "USD Swap_1")
         #
         all_swaps = vcat(example["portfolio"]...)
         obs_times = 0.0:1.0/4:10.0
-        scens = DiffFusion.scenarios(all_swaps, obs_times, path, "")
+        scens = DiffFusion.scenarios(all_swaps, obs_times, path, "USD")
         plot_swap(scens, "Portfolio")
         #
     end
@@ -389,9 +389,9 @@ using YAML
         obs_times = 0.0:1.0/4:10.0
         #
         @info "Run single-threaded scenario valuation..."
-        @time scens_st = DiffFusion.scenarios(all_swaps, obs_times, path, "", with_progress_bar=false)
+        @time scens_st = DiffFusion.scenarios(all_swaps, obs_times, path, "USD", with_progress_bar=false)
         @info "Run multi-threaded scenario valuation..."
-        @time scens_mt = scenarios_mt(all_swaps, obs_times, path, "")
+        @time scens_mt = scenarios_mt(all_swaps, obs_times, path, "USD")
         @test scens_mt.X == scens_st.X
         # println(maximum(abs.(scens_mt.X - scens_st.X)))
         #

--- a/test/componenttests/scenarios/swaptions_expected_exposure.jl
+++ b/test/componenttests/scenarios/swaptions_expected_exposure.jl
@@ -187,7 +187,7 @@ using UnicodePlots
         "berm/10-nc-2",
         [ exercise_2y, exercise_4y, exercise_6y, exercise_8y, ],
         1.0, # long option
-        "", # default discounting (curve key)
+        "EUR", # default discounting (curve key)
         make_regression_variables,
         nothing, # path
         nothing, # make_regression
@@ -198,7 +198,7 @@ using UnicodePlots
         "berm/10-nc-2 (regr_on_regr)",
         [ exercise_2y, exercise_4y, exercise_6y, exercise_8y, ],
         1.0, # long option
-        "", # default discounting (curve key)
+        "EUR", # default discounting (curve key)
         make_regression_variables,
         nothing, # path
         nothing, # make_regression
@@ -217,16 +217,16 @@ using UnicodePlots
     
     # Scenario Calculation
     
-    scens = DiffFusion.scenarios(vanilla_swap, times, path, "", with_progress_bar=false);
+    scens = DiffFusion.scenarios(vanilla_swap, times, path, "EUR", with_progress_bar=false);
     vanilla_swap_scens = DiffFusion.aggregate(scens, false, true)
     
-    swaption_2y_scens = DiffFusion.scenarios([swaption_2y], times, path, "", with_progress_bar=false)
-    swaption_4y_scens = DiffFusion.scenarios([swaption_4y], times, path, "", with_progress_bar=false)
-    swaption_6y_scens = DiffFusion.scenarios([swaption_6y], times, path, "", with_progress_bar=false)
-    swaption_8y_scens = DiffFusion.scenarios([swaption_8y], times, path, "", with_progress_bar=false)
+    swaption_2y_scens = DiffFusion.scenarios([swaption_2y], times, path, "EUR", with_progress_bar=false)
+    swaption_4y_scens = DiffFusion.scenarios([swaption_4y], times, path, "EUR", with_progress_bar=false)
+    swaption_6y_scens = DiffFusion.scenarios([swaption_6y], times, path, "EUR", with_progress_bar=false)
+    swaption_8y_scens = DiffFusion.scenarios([swaption_8y], times, path, "EUR", with_progress_bar=false)
     
-    berm_scens = DiffFusion.scenarios([berm], times, path, "", with_progress_bar=false)
-    berm_2_scens = DiffFusion.scenarios([berm_2], times, path, "", with_progress_bar=false)
+    berm_scens = DiffFusion.scenarios([berm], times, path, "EUR", with_progress_bar=false)
+    berm_2_scens = DiffFusion.scenarios([berm_2], times, path, "EUR", with_progress_bar=false)
     
     vanilla_swap_ee = DiffFusion.expected_exposure(vanilla_swap_scens)
     swaption_2y_ee = DiffFusion.expected_exposure(swaption_2y_scens)

--- a/test/componenttests/sensitivities/forwards_deltas.jl
+++ b/test/componenttests/sensitivities/forwards_deltas.jl
@@ -21,9 +21,9 @@ using ForwardDiff
         for obs_time in (0.0, 0.5, 2.0)
             # println("Obs_time: " * string(obs_time) * ".")
             payoffs = [ DiffFusion.Asset(obs_time, "EUR-USD") ]
-            model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
             # println(model_price)
-            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
             @test v == model_price
             # test deltas via manual FD
             shift = 1.0e-7
@@ -45,8 +45,8 @@ using ForwardDiff
                     path_u.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .+ shift)
                     path_d.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .- shift)
                 end
-                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
-                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
+                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                 delta = (model_price_u - model_price_d) / (2 * shift)
                 #
                 # println(alias * ": grad = " * string(grad) * ", delta = " * string(delta) * ".")
@@ -64,9 +64,9 @@ using ForwardDiff
         sim = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false)
         path = DiffFusion.path(sim, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
         payoffs = [ ]
-        model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
         @test model_price == 0.0
-        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
         @test v == model_price
     end
 
@@ -87,10 +87,10 @@ using ForwardDiff
         for (obs_time, g_ref) in zip((0.0, 0.5, 2.0,), gradient_vector)
             # println("Obs_time: " * string(obs_time) * ".")
             payoffs = [ DiffFusion.Asset(obs_time, "EUR-USD") ]
-            model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
             # println(model_price)
-            (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "", Zygote)
-            (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "", ForwardDiff)
+            (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", Zygote)
+            (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", ForwardDiff)
             @test v1 == model_price
             @test v2 == model_price
             @test isapprox(g1, g_ref, atol=1.0e-12)

--- a/test/componenttests/sensitivities/gradients.jl
+++ b/test/componenttests/sensitivities/gradients.jl
@@ -187,7 +187,7 @@ using Test
             [ L2 ],
             nothing,
             nothing,
-            "",
+            "EUR",
         )
 
         A2 = DiffFusion.AmcSum(
@@ -196,7 +196,7 @@ using Test
             [ L2 ],
             nothing,
             nothing,
-            "",
+            "EUR",
         )
 
         (v1, g1, ts_labels) = DiffFusion.model_price_and_deltas_vector(

--- a/test/componenttests/sensitivities/option_deltas.jl
+++ b/test/componenttests/sensitivities/option_deltas.jl
@@ -54,11 +54,11 @@ using Test
                 DiffFusion.ZeroBond(obs_time, pay_time, "USD"),
             ]
             payoffs = [ DiffFusion.AmcSum(
-                obs_time, [V], Z, path, make_regression, ""
+                obs_time, [V], Z, path, make_regression, "USD"
             )]
-            model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
             println(model_price)
-            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
             @test v == model_price
             # test deltas via manual FD
             shift = 1.0e-7
@@ -80,8 +80,8 @@ using Test
                     path_u.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .+ shift)
                     path_d.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .- shift)
                 end
-                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
-                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
+                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                 delta = (model_price_u - model_price_d) / (2 * shift)
                 #
                 println(alias * ": grad = " * string(grad) * ", delta = " * string(delta) * ".")
@@ -115,12 +115,12 @@ using Test
                     DiffFusion.ZeroBond(T, maturity_time, "USD"),
                 ]
                 U = put(T)
-                H = DiffFusion.AmcMax(T, [H], [U], Z, path, make_regression, "")
+                H = DiffFusion.AmcMax(T, [H], [U], Z, path, make_regression, "USD")
             end
             payoffs = [ H ]
-            model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
             println(model_price)
-            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
             @test v == model_price
             # test deltas via manual FD
             shift = 1.0e-7
@@ -142,8 +142,8 @@ using Test
                     path_u.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .+ shift)
                     path_d.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .- shift)
                 end
-                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
-                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
+                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                 delta = (model_price_u - model_price_d) / (2 * shift)
                 #
                 println(alias * ": grad = " * string(grad) * ", delta = " * string(delta) * ".")

--- a/test/componenttests/sensitivities/option_vegas.jl
+++ b/test/componenttests/sensitivities/option_vegas.jl
@@ -36,9 +36,9 @@ using ForwardDiff
         #
         for obs_time in (1.0, 2.0, 5.0,)
             payoffs = [ straddle(obs_time) ]
-            model_price = DiffFusion.model_price(payoffs, path_, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path_, nothing, "USD")
             println("Obs_time: " * string(obs_time) * ", model_price: " * string(model_price))
-            (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "")
+            (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "USD")
             @test v == model_price
             # Vega
             for key in keys(g)
@@ -60,14 +60,14 @@ using ForwardDiff
                         mdl_u = DiffFusion.build_model(model.alias, param_dict_u, model_dict)
                         sim_u = sim(mdl_u, ch)
                         path_u = DiffFusion.path(sim_u, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                        model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
+                        model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
                         #
                         param_dict_d = deepcopy(param_dict)
                         param_dict_d[key][param_key].values[k,1] -= shift
                         mdl_d = DiffFusion.build_model(model.alias, param_dict_d, model_dict)
                         sim_d = sim(mdl_d, ch)
                         path_d = DiffFusion.path(sim_d, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                        model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                        model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                         #
                         delta = (model_price_u - model_price_d) / (2 * shift)
                         # println(key * "/" * param_key * "/" * string(k) * ": grad = " * string(grad[k]) * ", delta = " * string(delta) * ".")
@@ -92,14 +92,14 @@ using ForwardDiff
                         mdl_u = DiffFusion.build_model(model.alias, param_dict_u, model_dict)
                         sim_u = sim(mdl_u, ch)
                         path_u = DiffFusion.path(sim_u, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                        model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
+                        model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
                         #
                         param_dict_d = deepcopy(param_dict)
                         param_dict_d[key][param_key].values[k,1] -= shift
                         mdl_d = DiffFusion.build_model(model.alias, param_dict_d, model_dict)
                         sim_d = sim(mdl_d, ch)
                         path_d = DiffFusion.path(sim_d, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                        model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                        model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                         #
                         delta = (model_price_u - model_price_d) / (2 * shift)
                         # println(key * "/" * param_key * "/" * string(k) * ": grad = " * string(grad[k]) * ", delta = " * string(delta) * ".")
@@ -115,14 +115,14 @@ using ForwardDiff
                 mdl_u = DiffFusion.build_model(model.alias, param_dict_u, model_dict)
                 sim_u = sim(mdl_u, param_dict_u["Full"])
                 path_u = DiffFusion.path(sim_u, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
+                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
                 #
                 param_dict_d = deepcopy(param_dict)
                 param_dict_d["Full"].correlations[k] -= shift
                 mdl_d = DiffFusion.build_model(model.alias, param_dict_d, model_dict)
                 sim_d = sim(mdl_d, param_dict_d["Full"])
                 path_d = DiffFusion.path(sim_d, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                 #
                 delta = (model_price_u - model_price_d) / (2 * shift)
                 # println(k * ": grad = " * string(g) * ", delta = " * string(delta) * ".")
@@ -144,9 +144,9 @@ using ForwardDiff
         #
         sim_ = sim(model, ch)
         path_ = DiffFusion.path(sim_, TestModels.ts_list, TestModels.context, DiffFusion.LinearPathInterpolation)
-        model_price = DiffFusion.model_price(payoffs, path_, nothing, "")
+        model_price = DiffFusion.model_price(payoffs, path_, nothing, "USD")
         #
-        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "")
+        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "USD")
         @test v == model_price
         #println(g)
     end
@@ -189,10 +189,10 @@ using ForwardDiff
         #
         sim_ = sim(model, TestModels.ch_one)
         path_ = DiffFusion.path(sim_, TestModels.ts_list, context, DiffFusion.LinearPathInterpolation)
-        model_price = DiffFusion.model_price(payoffs, path_, nothing, "")
+        model_price = DiffFusion.model_price(payoffs, path_, nothing, "USD")
         # println(model_price)
         #
-        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, context, nothing, "")
+        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim, TestModels.ts_list, context, nothing, "USD")
         @test v == model_price
         # println(g)
     end
@@ -230,10 +230,10 @@ using ForwardDiff
         #
         for (obs_time, g_ref) in zip((1.0, 2.0, 5.0,), gradient_vector)
             payoffs = [ straddle(obs_time) ]
-            model_price = DiffFusion.model_price(payoffs, path_, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path_, nothing, "USD")
             println("Obs_time: " * string(obs_time) * ", model_price: " * string(model_price))
-            (v1, g1, l1) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "", Zygote)
-            (v2, g2, l2) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "", ForwardDiff)
+            (v1, g1, l1) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "USD", Zygote)
+            (v2, g2, l2) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim, TestModels.ts_list, TestModels.context, nothing, "USD", ForwardDiff)
             @test v1 == model_price
             @test v2 == model_price
             @test isapprox(g1, g_ref, atol=1.0e-12)

--- a/test/componenttests/sensitivities/swap_deltas.jl
+++ b/test/componenttests/sensitivities/swap_deltas.jl
@@ -24,9 +24,9 @@ using Test
                 DiffFusion.discounted_cashflows(swap[1], obs_time),
                 DiffFusion.discounted_cashflows(swap[2], obs_time),
             )
-            model_price = DiffFusion.model_price(payoffs, path, nothing, "")
+            model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
             # println(model_price)
-            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+            (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
             @test v == model_price
             # test deltas via manual FD
             shift = 1.0e-7
@@ -48,8 +48,8 @@ using Test
                     path_u.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .+ shift)
                     path_d.ts_dict[alias] = DiffFusion.BackwardFlatParameter(alias, path.ts_dict[alias].times, path.ts_dict[alias].values .- shift)
                 end
-                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "")
-                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "")
+                model_price_u = DiffFusion.model_price(payoffs, path_u, nothing, "USD")
+                model_price_d = DiffFusion.model_price(payoffs, path_d, nothing, "USD")
                 delta = (model_price_u - model_price_d) / (2 * shift)
                 #
                 println(alias * ": grad = " * string(grad) * ", delta = " * string(delta) * ".")

--- a/test/componenttests/sensitivities/swaptions_delta_vega.jl
+++ b/test/componenttests/sensitivities/swaptions_delta_vega.jl
@@ -190,7 +190,7 @@ using UnicodePlots
         "berm/10-nc-2",
         [ exercise_2y, exercise_4y, exercise_6y, exercise_8y, ],
         1.0, # long option
-        "", # default discounting (curve key)
+        "EUR", # default discounting (curve key)
         make_regression_variables,
         nothing, # path
         nothing, # make_regression
@@ -200,7 +200,7 @@ using UnicodePlots
         "berm/4y",
         [ exercise_4y, ],
         1.0, # long option
-        "", # default discounting (curve key)
+        "EUR", # default discounting (curve key)
         make_regression_variables,
         nothing, # path
         nothing, # make_regression
@@ -239,7 +239,7 @@ using UnicodePlots
             DiffFusion.discounted_cashflows(swaption_4y, 1.0),
             path,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v1, g1, ts_labels)
@@ -248,7 +248,7 @@ using UnicodePlots
             DiffFusion.discounted_cashflows(berm_4y, 1.0),
             path,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v2, g2, ts_labels)
@@ -257,7 +257,7 @@ using UnicodePlots
             DiffFusion.discounted_cashflows(berm_10nc2, 1.0),
             path,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v3, g3, ts_labels)
@@ -284,7 +284,7 @@ using UnicodePlots
             ts_list,
             context,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v1, g1, ts_labels)
@@ -296,7 +296,7 @@ using UnicodePlots
             ts_list,
             context,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v2, g2, ts_labels)
@@ -308,7 +308,7 @@ using UnicodePlots
             ts_list,
             context,
             1.0,
-            "",
+            "EUR",
             DiffFusion.ForwardDiff
         )
         print_results(v3, g3, ts_labels)

--- a/test/unittests/analytics/scenario_analytics.jl
+++ b/test/unittests/analytics/scenario_analytics.jl
@@ -111,7 +111,7 @@ using Test
         path_ = DiffFusion.path(sim, ts, context, DiffFusion.LinearPathInterpolation)
         #
         obs_times = 1:0.5:10
-        scens = DiffFusion.scenarios([leg1, leg2], obs_times, path_, "", with_progress_bar = false)
+        scens = DiffFusion.scenarios([leg1, leg2], obs_times, path_, "USD", with_progress_bar = false)
         @test size(scens.X) == (n_paths, length(obs_times), 2)
         #
         path_ = DiffFusion.path(sim, ts, context, DiffFusion.NoPathInterpolation)
@@ -123,7 +123,7 @@ using Test
         n_paths = 2^3
         sim = DiffFusion.simple_simulation(m, ch, times, n_paths, with_progress_bar = false)
         path_ = DiffFusion.path(sim, ts, context, DiffFusion.LinearPathInterpolation)
-        scens = DiffFusion.scenarios([leg1, leg2], times, path_, "", with_progress_bar = true)
+        scens = DiffFusion.scenarios([leg1, leg2], times, path_, "USD", with_progress_bar = true)
         #
         average_paths = false
         aggregate_legs = false

--- a/test/unittests/analytics/valuations.jl
+++ b/test/unittests/analytics/valuations.jl
@@ -42,18 +42,18 @@ using ForwardDiff
         @info "Start testing AD Deltas..."
         payoffs = [ DiffFusion.Asset(2.0, "EUR-USD")]
         #
-        model_price = DiffFusion.model_price(payoffs, path, nothing, "")
-        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "")
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
         @test v == model_price
         #
         model_price = DiffFusion.model_price(payoffs, path, nothing, nothing)
         (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, nothing)
         @test v == model_price
         #
-        model_price = DiffFusion.model_price(payoffs, path, nothing, "")
-        (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "", Zygote)
-        (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "", ForwardDiff)
-        (v3, g3, l3) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "", FiniteDifferences)
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", Zygote)
+        (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", ForwardDiff)
+        (v3, g3, l3) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", FiniteDifferences)
         @test v1 == model_price
         @test v2 == model_price
         @test v2 == model_price
@@ -79,14 +79,14 @@ using ForwardDiff
         sim_func(model, ch) = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false)
         #
         payoffs = [ DiffFusion.Asset(2.0, "EUR-USD")]
-        model_price = DiffFusion.model_price(payoffs, path, nothing, "")
-        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim_func, ts_list, context, nothing, "")
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim_func, ts_list, context, nothing, "USD")
         @test v == model_price
         #
-        model_price = DiffFusion.model_price(payoffs, path, nothing, "")
-        (v1, g1, l1) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "", Zygote)
-        (v2, g2, l2) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "", ForwardDiff)
-        (v3, g3, l3) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "", FiniteDifferences)
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v1, g1, l1) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", Zygote)
+        (v2, g2, l2) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", ForwardDiff)
+        (v3, g3, l3) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", FiniteDifferences)
         @test v1 == model_price
         @test v2 == model_price
         @test v3 == model_price

--- a/test/unittests/examples/products.jl
+++ b/test/unittests/examples/products.jl
@@ -32,6 +32,7 @@ using YAML
     """
     config/instruments:
       seed: 123456
+      discount_curve_key: "USD:SOFR"
       swap_types:
         - USD
         - EUR

--- a/test/unittests/examples/scenarios.jl
+++ b/test/unittests/examples/scenarios.jl
@@ -79,7 +79,6 @@ using Test
             with_progress_bar=with_progress_bar
         )
         @test size(scens.X) == (8, 11, 32)
-        println(size(scens.X))
     end
 
 end

--- a/test/unittests/examples/simulations.jl
+++ b/test/unittests/examples/simulations.jl
@@ -36,7 +36,7 @@ using Test
         @test path_ == example[alias(sim.model) * "/path"]
         #
         n_paths = example["config/simulation"]["n_paths"]
-        @test size(at(DiffFusion.Numeraire(1.0, ""), path_)) == (n_paths,)
+        @test size(at(DiffFusion.Numeraire(1.0, "USD"), path_)) == (n_paths,)
         #
         @test size(at(DiffFusion.BankAccount(1.0, "USD"), path_)) == (n_paths,)
         @test size(at(DiffFusion.BankAccount(1.0, "USD:SOFR"), path_)) == (n_paths,)

--- a/test/unittests/paths/path.jl
+++ b/test/unittests/paths/path.jl
@@ -237,7 +237,7 @@ end
     @testset "Stochastic model functions." begin
         p = DiffFusion.path(sim, ts, context)
         t = 2.0
-        @test isapprox(DiffFusion.numeraire(p, t, ""), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
+        @test isapprox(DiffFusion.numeraire(p, t, "USD"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
         #
         @test isapprox(DiffFusion.bank_account(p, t, "USD"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
         @test isapprox(DiffFusion.bank_account(p, t, "EUR"), exp(1.0 + 0.02*t) * ones(5), atol=1.0e-15)
@@ -372,7 +372,7 @@ end
         p = DiffFusion.path(det_sim, ts, det_context)
         t = 2.0
         T = 5.0
-        @test isapprox(DiffFusion.numeraire(p, t, ""), exp(0.03*t) * ones(1), atol=1.0e-15)
+        @test isapprox(DiffFusion.numeraire(p, t, "USD"), exp(0.03*t) * ones(1), atol=1.0e-15)
         #
         @test isapprox(DiffFusion.bank_account(p, t, "USD"), exp(0.03*t) * ones(1), atol=1.0e-15)
         @test isapprox(DiffFusion.bank_account(p, t, "EUR"), exp(0.02*t) * ones(1), atol=1.0e-15)

--- a/test/unittests/paths/simulated_path.jl
+++ b/test/unittests/paths/simulated_path.jl
@@ -88,7 +88,7 @@ using Test
         p = DiffFusion.path(sim, ts, context)
         for t in times[2:end]
             #
-            num = DiffFusion.numeraire(p, t, "")
+            num = DiffFusion.numeraire(p, t, "USD")
             one = (1.0 / DiffFusion.discount(ts[1], t)) ./ num
             # println(abs(mean(one) - 1.0))
             @test isapprox(mean(one), 1.0, atol=3.6e-3 )
@@ -147,7 +147,7 @@ using Test
         p = DiffFusion.path(sim, ts, context)
         for t in times[2:end]
             #
-            num = DiffFusion.numeraire(p, t, "")
+            num = DiffFusion.numeraire(p, t, "USD")
             one = (1.0 / DiffFusion.discount(ts[1], t)) ./ num
             # println(abs(mean(one) - 1.0))
             @test isapprox(mean(one), 1.0, atol=1.5e-3 )

--- a/test/unittests/products/bermudan_swaption_leg.jl
+++ b/test/unittests/products/bermudan_swaption_leg.jl
@@ -416,6 +416,7 @@ berm_2_00 =
             float_leg,
             [ 1.0, 2.0, 3.0, 3.5 ],
             -1.0,
+            "EUR:OIS"
         )
         @test isa(berm, DiffFusion.BermudanSwaptionLeg)
     end


### PR DESCRIPTION
This PR changes the behaviour of numeraire discount_curve_key handling.  
  - Require context_key consistent with numeraire context key
  - Make behaviour consistent with bank_account method
  - update bermudan_swaption_leg method
  - update examples yaml and setup
  - update unittests and componenttests

The change is inteded to remove ambigous handling of curve keys. The new methodology requires the user to explicitely specify the discounting currency in AMC payoffs and for scenario calculation. If the specification is not consistent with the used context then an exception is thrown.