### PR TITLE
Add serialisation for remote call Future objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.4.0"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -2,6 +2,7 @@ module DiffFusion
 
 using ChainRulesCore
 using DelimitedFiles
+using Distributed
 using Distributions
 using FiniteDifferences
 using ForwardDiff

--- a/test/unittests/serialisation/basic_types.jl
+++ b/test/unittests/serialisation/basic_types.jl
@@ -1,4 +1,5 @@
 using DiffFusion
+using Distributed
 using OrderedCollections
 using Test
 
@@ -17,6 +18,13 @@ using Test
             "A" => 1,
             "C" => "Std"
         )
+    end
+
+    @testset "Simple Remote call serialisation." begin
+        f = remotecall(()-> "Std", workers()[1])
+        @test DiffFusion.serialise(f) == "Std"
+        f = remotecall(()-> 42.1, workers()[1])
+        @test DiffFusion.serialise(f) == 42.1
     end
 
     @testset "Basic object types de-serialisation" begin


### PR DESCRIPTION
This PR adds functionality to serialise and de-serialise Future objects from remote calls.

The implemented approach requires the underlying result of the Future object to be calculated. That is, we invoke fetch before serialising and de-serialising any Furure objects.

This functionality is intended to allow asyncronous creation of objects via computationally expensive calculations. Typical intended use cases are Monte-Carlo simulations and scenario generation.