### PR TITLE
Add a new asset model using CEV process

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -41,6 +41,7 @@ include("termstructures/volatility/VolatilityTermstructures.jl")
 
 include("models/Model.jl")
 include("models/asset/AssetModel.jl")
+include("models/asset/CevAssetModel.jl")
 include("models/asset/LognormalAssetModel.jl")
 include("models/hybrid/CompositeModel.jl")
 include("models/hybrid/SimpleModel.jl")

--- a/src/chainrules/models.jl
+++ b/src/chainrules/models.jl
@@ -14,6 +14,7 @@ ChainRulesCore.@non_differentiable _intersect_interval(s::ModelTime, t::ModelTim
 # do not differentiate time grid operations
 ChainRulesCore.@non_differentiable parameter_grid(m::Model)
 ChainRulesCore.@non_differentiable parameter_grid(m::LognormalAssetModel)
+ChainRulesCore.@non_differentiable parameter_grid(m::CevAssetModel)
 ChainRulesCore.@non_differentiable parameter_grid(m::MarkovFutureModel)
 ChainRulesCore.@non_differentiable parameter_grid(m::CompositeModel)
 ChainRulesCore.@non_differentiable parameter_grid(m::GaussianHjmModel)

--- a/src/models/asset/CevAssetModel.jl
+++ b/src/models/asset/CevAssetModel.jl
@@ -1,0 +1,268 @@
+
+"""
+    struct CevAssetModel <: AssetModel
+        alias::String
+        sigma_x::BackwardFlatVolatility
+        skew_x::BackwardFlatParameter
+        state_alias::AbstractVector
+        factor_alias::AbstractVector
+        correlation_holder::CorrelationHolder
+        quanto_model::Union{AssetModel, Nothing}
+    end
+
+A `CevAssetModel` is a model for simulating an asset price in a
+Constant Elasticity of Variance model.
+"""
+struct CevAssetModel <: AssetModel
+    alias::String
+    sigma_x::BackwardFlatVolatility
+    skew_x::BackwardFlatParameter
+    state_alias::AbstractVector
+    factor_alias::AbstractVector
+    correlation_holder::CorrelationHolder
+    quanto_model::Union{AssetModel, Nothing}
+end
+
+
+"""
+    cev_asset_model(
+        alias::String,
+        sigma_x::BackwardFlatVolatility,
+        skew_x::BackwardFlatParameter,
+        ch::CorrelationHolder,
+        quanto_model::Union{AssetModel, Nothing}
+        )
+
+Create a CevAssetModel.
+"""
+function cev_asset_model(
+    alias::String,
+    sigma_x::BackwardFlatVolatility,
+    skew_x::BackwardFlatParameter,
+    ch::CorrelationHolder,
+    quanto_model::Union{AssetModel, Nothing}
+    )
+    @assert size(sigma_x.values)[1] == 1
+    @assert size(skew_x.values)[1] == 1
+    state_alias = [ alias * "_x" ]
+    factor_alias = [ alias * "_x" ]
+    return CevAssetModel(alias, sigma_x, skew_x, state_alias, factor_alias, ch, quanto_model)
+end
+
+
+"""
+    parameter_grid(m::CevAssetModel)
+
+Return a list of times representing the (joint) grid points of piece-wise
+constant model parameters.
+
+This method is intended to be used in conjunction with time-integration
+mehods that require smooth integrand functions.
+"""
+function parameter_grid(m::CevAssetModel)
+    # better also add skew parameters here...
+    return m.sigma_x.times
+end
+
+"""
+    state_dependent_Theta(m::CevAssetModel)
+
+Return whether Theta requires a state vector input X.
+"""
+state_dependent_Theta(m::CevAssetModel) = true
+
+"""
+    state_alias_H(m::CevAssetModel)
+
+Return a list of state alias strings required for (H * X) calculation.
+"""
+state_alias_H(m::CevAssetModel) = state_alias(m)
+
+"""
+    state_dependent_H(m::CevAssetModel)
+
+Return whether H requires a state vector input X.
+"""
+state_dependent_H(m::CevAssetModel) = false
+
+"""
+    factor_alias_Sigma(m::CevAssetModel)
+
+Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.
+"""
+factor_alias_Sigma(m::CevAssetModel) = factor_alias(m)
+
+"""
+    state_dependent_Sigma(m::CevAssetModel)
+
+Return whether Sigma requires a state vector input X.
+"""
+state_dependent_Sigma(m::CevAssetModel) = true
+
+
+"""
+    asset_volatility(
+        m::CevAssetModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return a state-independent volatility function sigma(u) for the interval (s,t).
+"""
+function asset_volatility(
+    m::CevAssetModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_Sigma(m)
+    @assert size(X.X)[2] == 1  # require a single state
+    x_s = X(state_alias(m)[1])[1]  # this should be a scalar
+    sigma(u) = m.sigma_x(u, TermstructureScalar) * exp(m.skew_x(u, TermstructureScalar) * x_s)
+    return sigma
+end
+
+# Model functions for CEV model duplicate code from LognormalModel.
+# Consider refactoring to avoid code duplication.
+
+"""
+    Theta(
+        m::CevAssetModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return the deterministic drift component for simulation over the time period [s, t].
+"""
+function Theta(
+    m::CevAssetModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_Theta(m)
+    @assert size(X.X)[2] == 1  # require a single state
+    sigma = asset_volatility(m, s, t, X)
+    # alpha is a vector-valued function
+    alpha = quanto_drift(factor_alias(m), m.quanto_model, s, t, X)
+    f(u) = sigma(u) * (sigma(u) +  2*alpha(u)[1])
+    val = _scalar_integral(f, s, t, parameter_grid(m))
+    return [ -0.5 * val ]
+end
+
+
+"""
+    H_T(
+        m::CevAssetModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return the transposed of the convection matrix H for simulation over the time period
+[s, t].
+"""
+function H_T(
+    m::CevAssetModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_H(m)
+    return ones(1,1)
+end
+
+
+"""
+    Sigma_T(
+        m::CevAssetModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::Union{ModelState, Nothing} = nothing,
+        )
+
+Return a matrix-valued function representing the volatility matrix function.
+
+The signature of the resulting function is (u::ModelTime). Here, u represents the
+observation time.
+"""
+function Sigma_T(
+    m::CevAssetModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::Union{ModelState, Nothing} = nothing,
+    )
+    @assert isnothing(X) == !state_dependent_Sigma(m)
+    @assert size(X.X)[2] == 1  # require a single state
+    sigma = asset_volatility(m, s, t, X)
+    f(u) = sigma(u) * ones(1,1)
+    return f
+end
+
+
+"""
+    log_asset(m::CevAssetModel, model_alias::String, t::ModelTime, X::ModelState)
+
+Retrieve the normalised state variable from an asset model.
+"""
+function log_asset(m::CevAssetModel, model_alias::String, t::ModelTime, X::ModelState)
+    @assert alias(m) == model_alias
+    return X(state_alias(m)[1])
+end
+
+
+"""
+    simulation_parameters(
+        m::CevAssetModel,
+        ch::Union{CorrelationHolder, Nothing},
+        s::ModelTime,
+        t::ModelTime,
+        )
+
+Pre-calculate parameters that are used in state-dependent Theta and Sigma calculation.
+"""
+function simulation_parameters(
+    m::CevAssetModel,
+    ch::Union{CorrelationHolder, Nothing},
+    s::ModelTime,
+    t::ModelTime,
+    )
+    f_sigma(u) = m.sigma_x(u, TermstructureScalar)^2
+    sigma_av = sqrt(_scalar_integral(f_sigma, s, t, parameter_grid(m)) / (t -s))
+    f_skew(u) = m.skew_x(u, TermstructureScalar)
+    skew_av = _scalar_integral(f_skew, s, t, parameter_grid(m))  / (t -s)
+    return (
+        sigma_av = sigma_av,
+        skew_av = skew_av,
+    )
+end
+
+
+"""
+    diagonal_volatility(
+        m::CevAssetModel,
+        s::ModelTime,
+        t::ModelTime,
+        X::ModelState,
+        )
+
+Calculate the path-dependent volatilities for CevAssetModel.
+
+`X` is supposed to hold a state matrix of size `(n, p)`. Here, `n` is
+`length(state_alias(m))` and `p` is the number of paths.
+
+The method returns a matrix of size `(n, p)`.
+"""
+function diagonal_volatility(
+    m::CevAssetModel,
+    s::ModelTime,
+    t::ModelTime,
+    X::ModelState,
+    )
+    @assert isa(X.params, NamedTuple)
+    x_s = X(state_alias(m)[1])  # this is a vector of the x-variable
+    vol = X.params.sigma_av * exp.(X.params.skew_av * x_s)
+    return reshape(vol, (1,:))
+end

--- a/src/serialisation/Models.jl
+++ b/src/serialisation/Models.jl
@@ -56,6 +56,28 @@ end
 
 
 """
+    serialise(o::CevAssetModel)
+
+Serialise CevAssetModel.
+"""
+function serialise(o::CevAssetModel)
+    d = OrderedDict{String, Any}()
+    d["typename"]    = string(typeof(o))
+    d["constructor"] = "cev_asset_model"
+    d["alias"]       = serialise(o.alias)
+    d["sigma_x"]     = serialise(o.sigma_x)
+    d["skew_x"]      = serialise(o.skew_x)
+    d["correlation_holder"] = serialise_key(o.correlation_holder.alias)
+    if isnothing(o.quanto_model)
+        d["quanto_model"] = serialise(o.quanto_model)
+    else
+        d["quanto_model"] = serialise_key(o.quanto_model.alias)
+    end
+    return d
+end
+
+
+"""
     serialise(o::SimpleModel)
 
 Serialise SimpleModel.

--- a/test/unittests/models/asset/asset.jl
+++ b/test/unittests/models/asset/asset.jl
@@ -15,6 +15,7 @@ using Test
         @test_throws ErrorException DiffFusion.asset_volatility(m, 1.0, 2.0, SX)
     end
 
+    include("cev_asset_model.jl")
     include("lognormal_asset_model.jl")
     include("asset_volatility_and_calibration.jl")
 

--- a/test/unittests/models/asset/cev_asset_model.jl
+++ b/test/unittests/models/asset/cev_asset_model.jl
@@ -1,0 +1,131 @@
+
+using DiffFusion
+using Test
+
+@testset "CEV asset model methods." begin
+
+    ch = DiffFusion.correlation_holder("Std")
+    DiffFusion.set_correlation!(ch, "EUR-USD_x", "EUR-GBP_x", 0.25)
+    sigma_x = DiffFusion.backward_flat_volatility(
+        "Std",
+        [ 1., 2., 5., 10. ],
+        [ 15. 10. 20. 30.; ],
+    )
+    skew_x = DiffFusion.backward_flat_parameter(
+        "Std",
+        [ 1., 2., 5., 10. ],
+        [ -0.25 -0.25 -0.25 -0.35; ],
+    )
+
+    @testset "CEV model setup" begin
+        m = DiffFusion.cev_asset_model("EUR-USD", sigma_x, skew_x, ch, nothing)
+        @test DiffFusion.alias(m) == "EUR-USD"
+        @test DiffFusion.state_alias(m) == [ "EUR-USD_x" ]
+        @test DiffFusion.factor_alias(m) == [ "EUR-USD_x" ]
+        @test DiffFusion.state_alias_H(m) == [ "EUR-USD_x" ]
+        @test DiffFusion.factor_alias_Sigma(m) == [ "EUR-USD_x" ]
+        @test DiffFusion.state_dependent_Theta(m) == true
+        @test DiffFusion.state_dependent_H(m) == false
+        @test DiffFusion.state_dependent_Sigma(m) == true
+    end
+
+    @testset "Model functions without quanto." begin
+        m = DiffFusion.cev_asset_model("EUR-USD", sigma_x, skew_x, ch, nothing)
+        SX = DiffFusion.model_state(
+            zeros(1,1),
+            DiffFusion.alias_dictionary(m.state_alias),
+            nothing,
+        )
+        #
+        vol = DiffFusion.asset_volatility(m, 0.0, 10.0, SX)
+        @test vol(0.5) == 15.
+        @test vol(1.0) == 15.
+        @test vol(1.5) == 10.
+        @test vol(12.5) == 30.
+        #
+        theta = DiffFusion.Theta(m, 0.0, 1.0, SX)
+        @test size(theta) == (1,)
+        @test theta[1] == -0.5 * 225.
+        theta = DiffFusion.Theta(m, 3.0, 8.0, SX)
+        theta_ref = -0.5 * (2*400. + 3*900.)
+        @test isapprox(theta[1], theta_ref, atol=2.1e-5)
+        #
+        @test DiffFusion.H_T(m, 0.5, 12.5) == ones(1,1)
+        #
+        @test DiffFusion.Sigma_T(m, 0.5, 12.5, SX)(0.5) == 15. * ones(1,1)
+        @test DiffFusion.Sigma_T(m, 0.5, 12.5, SX)(5.0) == 20. * ones(1,1)
+        @test DiffFusion.Sigma_T(m, 0.5, 12.5, SX)(9.0) == 30. * ones(1,1)
+        @test DiffFusion.Sigma_T(m, 0.5, 12.5, SX)(11.0) == 30. * ones(1,1)
+        #
+        x_s = 0.10
+        SX = DiffFusion.model_state(
+            zeros(1,1) .+ x_s,
+            DiffFusion.alias_dictionary(m.state_alias),
+            nothing,
+        )
+        #
+        vol = DiffFusion.asset_volatility(m, 0.0, 10.0, SX)
+        @test vol(0.5) == 15. * exp(-0.25*x_s)
+        @test vol(1.0) == 15. * exp(-0.25*x_s)
+        @test vol(1.5) == 10. * exp(-0.25*x_s)
+        @test vol(12.5) == 30. * exp(-0.35*x_s)
+    end
+
+    @testset "Model Theta with quanto." begin
+        # qm = DiffFusion.lognormal_asset_model("EUR-GBP", sigma_x, ch, nothing)
+        qm = DiffFusion.cev_asset_model("EUR-GBP", sigma_x, skew_x, ch, nothing)
+        m = DiffFusion.cev_asset_model("EUR-USD", sigma_x, skew_x, ch, qm)
+        SX = DiffFusion.model_state(
+            zeros(2,1) .+ [0.0, 0.0],
+            DiffFusion.alias_dictionary(["EUR-USD_x", "EUR-GBP_x"]),
+            nothing,
+        )
+        #
+        @test DiffFusion.quanto_drift(["EUR-USD_x"], qm, 0.5, 12.5, SX)(0.5) == [ 0.25 * 15. ]
+        @test DiffFusion.quanto_drift(["EUR-USD_x"], qm, 0.5, 12.5, SX)(6.5) == [ 0.25 * 30. ]
+        @test DiffFusion.quanto_drift(["EUR-USD_x"], qm, 0.5, 12.5, SX)(10.5) == [ 0.25 * 30. ]
+        #
+        theta = DiffFusion.Theta(m, 0.0, 1.0, SX)
+        @test size(theta) == (1,)
+        @test theta[1] == -0.5 * 15. * (15. + 2*0.25*15. )
+        #
+        theta = DiffFusion.Theta(m, 3.0, 8.0, SX)
+        theta_ref = -0.5 * (2. * 20. * (20. + 2*0.25*20.)  + 3. * 30. * (30. + 2*0.25*30.))
+        @test isapprox(theta[1], theta_ref, atol=3.1e-5)
+        #
+    end
+
+    @testset "Covariance calculation" begin
+        m = DiffFusion.cev_asset_model("EUR-USD", sigma_x, skew_x, ch, nothing)
+        SX = DiffFusion.model_state(
+            zeros(2,1) .+ [0.0, 0.0],
+            DiffFusion.alias_dictionary(["EUR-USD_x", "EUR-GBP_x"]),
+            nothing,
+        )
+        @test DiffFusion.covariance(m,nothing,0.0,1.0,SX) == reshape([ 225.], (1,1))
+        @test isapprox(DiffFusion.covariance(m,nothing,3.0,8.0,SX)[1,1], 2*400. + 3*900., atol=4.1e-5)
+    end
+
+    @testset "Access model state variables" begin
+        m = DiffFusion.cev_asset_model("EUR-USD", sigma_x, skew_x, ch, nothing)
+        dict = DiffFusion.alias_dictionary(DiffFusion.state_alias(m))
+        X = [ 1. ] * [ 1., 2., 3. ]'
+        SX = DiffFusion.model_state(X, dict)
+        @test DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX) == [ 1., 2., 3. ]
+        @test_throws AssertionError DiffFusion.log_asset(m, "USD-EUR", 1.0, SX)
+        #
+        dict = DiffFusion.alias_dictionary([ "GBP_x_1", "EUR-USD_x", "EUR_GBP_x" ])
+        X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'
+        SX = DiffFusion.model_state(X, dict)
+        @test DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX) == [ 2., 4., 6. ]
+        #
+        dict = DiffFusion.alias_dictionary([ "GBP_x_1", "EUR-USD_s", "EUR_GBP_x" ])
+        X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'
+        SX = DiffFusion.model_state(X, dict)
+        @test_throws KeyError DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX)
+        @test_throws ErrorException DiffFusion.log_bank_account(m, DiffFusion.alias(m), 1.0, SX)
+        @test_throws ErrorException DiffFusion.log_zero_bond(m, DiffFusion.alias(m), 1.0, 2.0, SX)
+    end
+
+
+end

--- a/test/unittests/serialisation/models.jl
+++ b/test/unittests/serialisation/models.jl
@@ -180,6 +180,76 @@ using YAML
         @test string(o) == string(models[4])
     end
 
+    @testset "CevAssetModel (de-)serialisation." begin
+        models = setup_models(ch_full)
+        σ = DiffFusion.flat_volatility(0.15)
+        γ = DiffFusion.flat_parameter(1.3)
+        m = DiffFusion.cev_asset_model("EUR-USD", σ, γ, ch_full, nothing)
+        ref_dict = Dict(
+            "EUR-USD" => models[2],
+            "One" => ch_one,
+            "Full" => ch_full
+        )
+        #
+        s = DiffFusion.serialise(m)
+        d = OrderedDict(
+            "typename" => "DiffFusion.CevAssetModel",
+            "constructor" => "cev_asset_model",
+            "alias" => "EUR-USD",
+            "sigma_x" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatVolatility",
+                "constructor" => "BackwardFlatVolatility",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[0.15]]
+                ),
+            "skew_x" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[1.3]]
+                ),
+                "correlation_holder" => "{Full}",
+            "quanto_model" => "nothing",
+        )
+        o = DiffFusion.deserialise(d, ref_dict)
+        @test s == d
+        @test string(o) == string(m)
+        #
+        m = DiffFusion.cev_asset_model("SXE50", σ, γ, ch_full, models[2])
+        ref_dict = Dict(
+            "EUR-USD" => models[2],
+            "One" => ch_one,
+            "Full" => ch_full
+        )
+        s = DiffFusion.serialise(m)
+        d = OrderedDict(
+            "typename" => "DiffFusion.CevAssetModel",
+            "constructor" => "cev_asset_model",
+            "alias" => "SXE50",
+            "sigma_x" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatVolatility",
+                "constructor" => "BackwardFlatVolatility",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[0.15]]
+                ),
+            "skew_x" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[1.3]]
+                ),
+            "correlation_holder" => "{Full}",
+            "quanto_model" => "{EUR-USD}",
+        )
+        o = DiffFusion.deserialise(d, ref_dict)
+        @test s == d
+        @test string(o) == string(m)
+    end
+
     @testset "SimpleModel (de-)serialisation." begin
         models = setup_models(ch_one)
         ref_dict = Dict(

--- a/test/unittests/serialisation/rebuild_models.jl
+++ b/test/unittests/serialisation/rebuild_models.jl
@@ -194,4 +194,23 @@ using Test
         # println(v)
     end
 
+    @testset "CevAssetModel re-build" begin
+        σ = DiffFusion.flat_volatility(0.15)
+        γ = DiffFusion.flat_parameter(1.3)
+        m = DiffFusion.cev_asset_model("EUR-USD", σ, γ, ch_full, nothing)
+        d = DiffFusion.model_parameters(m)
+        (l, v) = DiffFusion.model_volatility_values(m.alias, d)
+        #
+        p_dict = Dict{String, Any}( "Full" => ch_full )
+        for k in keys(d)
+            p_dict[k] = d[k]
+        end
+        DiffFusion.model_parameters!(p_dict, l, v)
+        m_dict = Dict{String, Any}()
+        m1 = DiffFusion.build_model(m.alias, p_dict, m_dict)
+        @test string(m1) == string(m)
+        # println(l)
+        # println(d)
+    end
+
 end


### PR DESCRIPTION
This PR adds a new asset model based on a (local volatility) CEV process. This aims modelling volatility smile for FX and equity models.
  - Add CevAssetModel and model tests
  - Add model serialisation and re-build
  - chainrules for CevAssetModel