### PR TITLE
Add reference rate volatility and correlation calculation

### DIFF
--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -99,6 +99,7 @@ include("analytics/Scenarios.jl")
 include("analytics/Analytics.jl")
 include("analytics/Collateral.jl")
 include("analytics/Valuations.jl")
+include("analytics/Covariances.jl")
 
 include("serialisation/Serialisations.jl")
 include("serialisation/Array.jl")

--- a/src/analytics/Covariances.jl
+++ b/src/analytics/Covariances.jl
@@ -1,0 +1,271 @@
+
+
+"""
+    reference_rate_scaling(
+        context_key::String,
+        term::ModelTime,
+        mdl::Model,
+        ctx::Context
+        )
+
+Return the scaling vector of a reference rate.
+
+A reference rate is specified as a stochastic process random variable
+`Y = A' X + b`. Here, `X` reprsents the model state variable, `A` is
+the resulting scaling vector and `b` is a deterministic function (not
+relevant for this purpose).
+
+Reference rates are continuous compounded zero rates and FX rates (or
+asset prices). Reference rates are identified by a `context_key`. In
+addition, zero rates are specified by a positive `term`. For FX rates
+we require `term` equal to zero.
+
+Reference rates for other asset classes are to be added.
+
+The model context `ctx` is used to identify corresponding model parameters
+and state variables of the `model`.
+"""
+function reference_rate_scaling(
+    context_key::String,
+    term::ModelTime,
+    mdl::Model,
+    ctx::Context
+    )
+    #
+    if context_key in keys(ctx.rates)
+        # we model a zero rate
+        @assert term > 0.0
+        model_alias = ctx.rates[context_key].model_alias
+        @assert !isnothing(model_alias)
+        if isa(mdl, SeparableHjmModel)
+            hjm_mdl = mdl
+        elseif isa(mdl, CompositeModel)
+            hjm_mdl = mdl.models[mdl.model_dict[model_alias]]
+            @assert isa(hjm_mdl, SeparableHjmModel)
+        else
+            error("Cannot calculate scaling for model " * model_alias * ".")
+        end
+        G = G_hjm(hjm_mdl, 0.0, term)
+        #
+        s_alias = state_alias(mdl)
+        first_alias = state_alias(hjm_mdl)[begin]
+        idx = findall(x->x==first_alias, s_alias)[begin]
+        A = vcat(
+            zeros(idx - 1),
+            G / term,
+            zeros(length(s_alias) - length(G) - (idx - 1)),
+        )
+        return A
+    elseif context_key in keys(ctx.assets)
+        # we model an FX rate or asset price
+        @assert term == 0.0
+        @assert isa(mdl, CompositeModel)
+        #
+        s_alias = state_alias(mdl)
+        #
+        asset_model_alias = ctx.assets[context_key].asset_model_alias
+        @assert !isnothing(asset_model_alias) # handle this case later
+        asset_model = mdl.models[mdl.model_dict[asset_model_alias]]
+        @assert isa(asset_model, AssetModel)
+        #
+        dom_model_alias = ctx.assets[context_key].domestic_model_alias
+        @assert !isnothing(dom_model_alias) # handle this case later
+        dom_model = mdl.models[mdl.model_dict[dom_model_alias]]
+        @assert isa(dom_model, SeparableHjmModel)
+        #
+        for_model_alias = ctx.assets[context_key].foreign_model_alias
+        @assert !isnothing(for_model_alias) # handle this case later
+        for_model = mdl.models[mdl.model_dict[for_model_alias]]
+        @assert isa(for_model, SeparableHjmModel)
+        #
+        A = zeros(0)
+        for m in mdl.models  # assume unique model alias
+            if alias(m) == asset_model_alias
+                A = vcat(A, [1.0])
+            elseif alias(m) == dom_model_alias
+                n = length(state_alias(dom_model))
+                A = vcat(A, zeros(n-1), [1.0])
+            elseif alias(m) == for_model_alias
+                n = length(state_alias(for_model))
+                A = vcat(A, zeros(n-1), [-1.0])
+            else
+                n = length(state_alias(m))
+                A = vcat(A, zeros(n))
+            end
+        end
+        return A
+    else
+        error("context_key " * context_key * " not found in Context.")
+    end
+end
+
+
+"""
+    reference_rate_scaling(
+        keys_and_terms::AbstractVector,
+        mdl::Model,
+        ctx::Context
+        )
+
+Return the scaling matrix of a reference rates. The scaling matrix
+represents a list of scaling vectors represented as matrix.
+
+`keys_and_terms` is a list of tuples. For each tuple, the first
+element represents the `context_key` of the reference rate. The
+second element represents the `term` of the reference rate.
+"""
+function reference_rate_scaling(
+    keys_and_terms::AbstractVector,
+    mdl::Model,
+    ctx::Context
+    )
+    # check reference rate spec
+    for elm in keys_and_terms
+        @assert length(elm) == 2
+        @assert isa(elm[1], AbstractString)
+        @assert isa(elm[2], Number)
+    end
+    A = hcat([
+        reference_rate_scaling(elm[1], elm[2], mdl, ctx)
+        for elm in keys_and_terms
+    ]...)
+    return A
+end
+
+
+"""
+    reference_rate_covariance(
+        Y1::AbstractVecOrMat,
+        Y2::AbstractVecOrMat,
+        mdl::Model,
+        ch::CorrelationHolder,
+        s::ModelTime,
+        t::ModelTime,
+        )
+
+Calculate the covariance matrix for two vector or
+matrices of reference rates.
+"""
+function reference_rate_covariance(
+    Y1::AbstractVecOrMat,
+    Y2::AbstractVecOrMat,
+    mdl::Model,
+    ch::CorrelationHolder,
+    s::ModelTime,
+    t::ModelTime,
+    )
+    #
+    C = covariance(mdl, ch, s, t)
+    return Y1' * C * Y2
+end
+
+
+"""
+    reference_rate_covariance(
+        Y1::Tuple,
+        Y2::Tuple,
+        mdl::Model,
+        ch::CorrelationHolder,
+        s::ModelTime,
+        t::ModelTime,
+        )
+
+Calculate the scalar covariance for two reference rates.
+
+Reference rates are encoded as tuples `Y1` and `Y2`.
+The first element of a tuple is the `context_key`. The
+second element of the tuple is the `term`.
+"""
+function reference_rate_covariance(
+    R1::Tuple,
+    R2::Tuple,
+    ctx::Context,
+    mdl::Model,
+    ch::CorrelationHolder,
+    s::ModelTime,
+    t::ModelTime,
+    )
+    #
+    Y1 = reference_rate_scaling(R1[1], R1[2], mdl, ctx)
+    Y2 = reference_rate_scaling(R2[1], R2[2], mdl, ctx)
+    return reference_rate_covariance(Y1, Y2, mdl, ch, s, t)
+end
+
+
+"""
+    reference_rate_covariance(
+        keys_and_terms::AbstractVector,
+        ctx::Context,
+        mdl::Model,
+        ch::CorrelationHolder,
+        s::ModelTime,
+        t::ModelTime,
+        )
+
+Calculate covariance matrix for a list of reference rates.
+
+`keys_and_terms` is a list of tuples. For each tuple, the first
+element represents the `context_key` of the reference rate. The
+second element represents the `term` of the reference rate.
+"""
+function reference_rate_covariance(
+    keys_and_terms::AbstractVector,
+    ctx::Context,
+    mdl::Model,
+    ch::CorrelationHolder,
+    s::ModelTime,
+    t::ModelTime,
+    )
+    #
+    Y = reference_rate_scaling(keys_and_terms, mdl, ctx)
+    return reference_rate_covariance(Y, Y, mdl, ch, s, t)
+end
+
+
+"""
+    reference_rate_volatility_and_correlation(
+        keys_and_terms::AbstractVector,
+        ctx::Context,
+        mdl::Model,
+        ch::CorrelationHolder,
+        s::ModelTime,
+        t::ModelTime,
+        )
+
+Calculate the volatility vector and correlation matrix
+for a list of reference rates.
+
+`keys_and_terms` is a list of tuples. For each tuple, the first
+element represents the `context_key` of the reference rate. The
+second element represents the `term` of the reference rate.
+"""
+function reference_rate_volatility_and_correlation(
+    keys_and_terms::AbstractVector,
+    ctx::Context,
+    mdl::Model,
+    ch::CorrelationHolder,
+    s::ModelTime,
+    t::ModelTime,
+    vol_eps::ModelValue = 1.0e-8,  # avoid division by zero
+    )
+    #
+    d = length(keys_and_terms)
+    cov = reference_rate_covariance(keys_and_terms, ctx, mdl, ch, s, t)
+    vol = sqrt.([ cov[i,i] for i in 1:d ] .* (1.0/(t-s) ))
+    #
+    corr_(i,j) = begin
+        if i<j
+            return corr_(j,i) # ensure symmetry
+        end
+        if i==j
+            return 1.0 + 0.0 * cov[i,j]  # ensure type-stability
+        end
+        # i > j
+        if (vol[i]>vol_eps) && (vol[j]>vol_eps)
+            return cov[i,j] / vol[i] / vol[j] / (t-s)
+        end
+        return 0.0 * cov[i,j]  # ensure type-stability
+    end
+    corr = [ corr_(i,j) for i in 1:d, j in 1:d ]
+    return (vol, corr)
+end

--- a/test/unittests/analytics/analytics.jl
+++ b/test/unittests/analytics/analytics.jl
@@ -6,5 +6,6 @@ using Test
     include("scenarios.jl")
     include("scenario_analytics.jl")
     include("collateral.jl")
+    include("covariances.jl")
 	
 end

--- a/test/unittests/analytics/covariances.jl
+++ b/test/unittests/analytics/covariances.jl
@@ -1,0 +1,366 @@
+
+using DiffFusion
+using Test
+
+@testset "Covariance calculation for reference rates." begin
+
+    ch_one = DiffFusion.correlation_holder("One")
+    #
+    get_correlation(alias::String) = begin
+        ch = DiffFusion.correlation_holder(alias)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_2", 0.5)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "EUR_f_3", 0.5)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_1", "USD_f_2", 0.5)
+        DiffFusion.set_correlation!(ch, "USD_f_2", "USD_f_3", 0.5)
+        DiffFusion.set_correlation!(ch, "USD_f_1", "USD_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "GBP_f_1", "GBP_f_2", 0.5)
+        DiffFusion.set_correlation!(ch, "GBP_f_2", "GBP_f_3", 0.5)
+        DiffFusion.set_correlation!(ch, "GBP_f_1", "GBP_f_3", 0.2)
+        #
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "USD-EUR_x", 0.1)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_1", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "USD_f_2", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "USD_f_3", "USD-EUR_x", 0.1)
+        #
+        DiffFusion.set_correlation!(ch, "GBP_f_1", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "GBP_f_2", "USD-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "GBP_f_3", "USD-EUR_x", 0.1)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "GBP-EUR_x", 0.1)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_1", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "USD_f_2", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "USD_f_3", "GBP-EUR_x", 0.1)
+        #
+        DiffFusion.set_correlation!(ch, "GBP_f_1", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "GBP_f_2", "GBP-EUR_x", 0.1)
+        DiffFusion.set_correlation!(ch, "GBP_f_3", "GBP-EUR_x", 0.1)
+        #
+        #
+        DiffFusion.set_correlation!(ch, "USD-EUR_x", "GBP-EUR_x", 0.1)
+        #
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "USD_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "USD_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "USD_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "USD_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "USD_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "USD_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "USD_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "USD_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "USD_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "GBP_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "GBP_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "EUR_f_3", "GBP_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_1", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_1", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_1", "GBP_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_2", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_2", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_2", "GBP_f_3", 0.2)
+        #
+        DiffFusion.set_correlation!(ch, "USD_f_3", "GBP_f_1", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_3", "GBP_f_2", 0.2)
+        DiffFusion.set_correlation!(ch, "USD_f_3", "GBP_f_3", 0.2)
+        #
+        #
+        return ch            
+    end
+
+    hybrid_model(ch) = begin
+        times = [ 0. ]
+        #
+        hjm_eur = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            DiffFusion.flat_parameter([ 1., 10., 20. ]),      # delta
+            DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ]),  # chi
+            DiffFusion.backward_flat_volatility("",times,[ 60. 60. 60. ]' * 1.0e-4),  # sigma
+            ch,
+            nothing,
+        )
+        fx_usd_eur = DiffFusion.lognormal_asset_model(
+            "USD-EUR",
+            DiffFusion.flat_volatility("", 0.10),
+            ch,
+            nothing,
+        )
+        hjm_usd = DiffFusion.gaussian_hjm_model(
+            "USD",
+            DiffFusion.flat_parameter([ 1., 10., 20. ]),      # delta
+            DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ]),  # chi
+            DiffFusion.backward_flat_volatility("",times,[ 80. 80. 80. ]' * 1.0e-4),  # sigma
+            ch,
+            fx_usd_eur,
+        )
+        fx_gbp_eur = DiffFusion.lognormal_asset_model(
+            "GBP-EUR",
+            DiffFusion.flat_volatility("", 0.10),
+            ch,
+            nothing,
+        )
+        hjm_gbp = DiffFusion.gaussian_hjm_model(
+            "GBP",
+            DiffFusion.flat_parameter([ 1., 10., 20. ]),      # delta
+            DiffFusion.flat_parameter([ 0.01, 0.10, 0.30 ]),  # chi
+            DiffFusion.backward_flat_volatility("",times,[ 80. 80. 80. ]' * 1.0e-4),  # sigma
+            ch,
+            fx_gbp_eur,
+        )
+        #
+        models = [ hjm_eur, fx_usd_eur, hjm_usd, fx_gbp_eur, hjm_gbp ]
+        return DiffFusion.simple_model("Std", models)
+    end
+    
+    empty_key = DiffFusion._empty_context_key
+    #
+    ctx = DiffFusion.Context("Std",
+        DiffFusion.NumeraireEntry("EUR", "EUR", Dict(empty_key => "yc/EUR:OIS")),
+        Dict{String, DiffFusion.RatesEntry}([
+            ("EUR", DiffFusion.RatesEntry("EUR","EUR",
+                Dict(
+                    empty_key => "yc/EUR:OIS",
+                ))),
+            ("USD", DiffFusion.RatesEntry("USD", "USD",
+                Dict(
+                    empty_key => "yc/USD:XCY",
+                ))),
+            ("GBP", DiffFusion.RatesEntry("GBP", "GBP",
+                Dict(
+                    empty_key => "yc/GBP:XCY",
+                ))),
+        ]),
+        Dict{String, DiffFusion.AssetEntry}([
+            ("USD-EUR", DiffFusion.AssetEntry("USD-EUR", "USD-EUR", "EUR", "USD", "pa/USD-EUR",
+                Dict(empty_key => "yc/EUR:OIS"), Dict(empty_key => "yc/USD:XCY"))
+            ),
+            ("GBP-EUR", DiffFusion.AssetEntry("GBP-EUR", "GBP-EUR", "EUR", "GBP", "pa/GBP-EUR",
+                Dict(empty_key => "yc/EUR:OIS"), Dict(empty_key => "yc/GBP:XCY"))
+            ),
+            ]),
+        Dict{String, DiffFusion.ForwardIndexEntry}(),
+        Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.FixingEntry}(),
+    )
+    
+    @testset "Test scaling vector calculation" begin
+        ch_full = get_correlation("Std")
+        mdl = hybrid_model(ch_full)
+        # println(DiffFusion.state_alias(mdl))
+        # println(DiffFusion.factor_alias(mdl))
+        #
+        # test constraints
+        @test_throws ErrorException DiffFusion.reference_rate_scaling("NoKey", 1.0, mdl, ctx)
+        @test_throws AssertionError DiffFusion.reference_rate_scaling("EUR", -1.0, mdl, ctx)
+        @test_throws AssertionError DiffFusion.reference_rate_scaling("USD", 0.0, mdl, ctx)
+        @test_throws AssertionError DiffFusion.reference_rate_scaling("USD-EUR", 1.0, mdl, ctx)
+        #
+        # zero rate scaling
+        #
+        A = DiffFusion.reference_rate_scaling("EUR", 10.0, mdl, ctx)
+        A_ref = vcat(
+            [ 0.9516258196404047, 0.6321205588285577, 0.3167376438773787 ],
+            zeros(11),
+        )
+        @test isapprox(A, A_ref, atol=1.0e-14)
+        #
+        A = DiffFusion.reference_rate_scaling("USD", 2.0, mdl, ctx)
+        A_ref = vcat(
+            zeros(5),
+            [ 0.9900663346622374, 0.9063462346100909, 0.7519806065099559 ],
+            zeros(6),
+        )
+        @test isapprox(A, A_ref, atol=1.0e-14)
+        #
+        A = DiffFusion.reference_rate_scaling("GBP", 0.25, mdl, ctx)
+        A_ref = vcat(
+            zeros(10),
+            [ 0.9987510410159661, 0.9876035188666954, 0.9634201822859619 ],
+            zeros(1),
+        )
+        @test isapprox(A, A_ref, atol=1.0e-14)
+        #
+        A = DiffFusion.reference_rate_scaling("EUR", 10.0, mdl.models[1], ctx)
+        A_ref = [ 0.9516258196404047, 0.6321205588285577, 0.3167376438773787, 0.0 ]
+        @test isapprox(A, A_ref, atol=1.0e-14)
+        #
+        # FX rate scaling
+        #
+        A = DiffFusion.reference_rate_scaling("USD-EUR", 0.0, mdl, ctx)
+        A_ref = vcat(
+            zeros(3),
+            [ 1.0, 1.0 ],  # EUR_s, USD-EUR_x
+            zeros(3),
+            [ -1.0 ], # USD_s
+            zeros(5),
+        )
+        @test A == A_ref
+        #
+        A = DiffFusion.reference_rate_scaling("GBP-EUR", 0.0, mdl, ctx)
+        A_ref = vcat(
+            zeros(3),
+            [ 1.0  ],  # EUR_s
+            zeros(5),
+            [ 1.0 ], # GBP-EUR_x
+            zeros(3),
+            [ -1.0 ], # GBP_s
+        )
+        @test A == A_ref
+        #
+        # println(A)
+        # println(A_ref)
+    end
+
+    @testset "Test scaling matrix calculation" begin
+        ch_full = get_correlation("Std")
+        mdl = hybrid_model(ch_full)
+        #
+        A = DiffFusion.reference_rate_scaling(
+            [
+                ("EUR", 1.0),
+                ("GBP-EUR", 0.0),
+            ], mdl, ctx)
+        A1 = DiffFusion.reference_rate_scaling("EUR", 1.0, mdl, ctx)
+        A2 = DiffFusion.reference_rate_scaling("GBP-EUR", 0.0, mdl, ctx)
+        @test A == hcat(A1, A2)
+        A = DiffFusion.reference_rate_scaling(
+            [
+                ("EUR", 1.0),
+                ("EUR", 5.0),
+                ("EUR", 10.0),
+                ("USD", 1.0),
+                ("USD", 5.0),
+                ("USD", 10.0),
+                ("GBP", 1.0),
+                ("GBP", 5.0),
+                ("GBP", 10.0),
+                ("USD-EUR", 0.0),
+                ("GBP-EUR", 0.0),
+            ], mdl, ctx)
+        @test size(A) == (14, 11)
+        # display(A)
+    end
+
+    @testset "Test covariance calculation" begin
+        ch_full = get_correlation("Std")
+        mdl = hybrid_model(ch_full)
+        term = 2.0
+        dt = 0.25
+        cov = DiffFusion.reference_rate_covariance(
+            ("EUR", term),
+            ("GBP-EUR", 0.0),
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        var_eur = DiffFusion.reference_rate_covariance(
+            ("EUR", term),
+            ("EUR", term),
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        var_gbp_eur = DiffFusion.reference_rate_covariance(
+            ("GBP-EUR", 0.0),
+            ("GBP-EUR", 0.0),
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        @test isapprox(sqrt(var_eur/dt),              0.0059616690952, atol=1.0e-13)  # gbp rates vol with mean reversion
+        @test isapprox(sqrt(var_gbp_eur/dt),          0.0999883698958, atol=1.0e-13)  # GBP-EUR fx vol
+        @test isapprox(cov/sqrt(var_eur*var_gbp_eur), 0.1060389153917, atol=1.0e-13)  # rates-fx correlation
+        #
+        C = DiffFusion.reference_rate_covariance(
+            [
+                ("EUR", term),
+                ("GBP-EUR", 0.0),
+            ],
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        @test isapprox(C[1,1], var_eur, atol=1.0e-14)
+        @test isapprox(C[2,2], var_gbp_eur, atol=1.0e-14)
+        @test isapprox(C[1,2], cov, atol=1.0e-14)
+    end
+
+    @testset "Test volatility and correlation calculation" begin
+        ch_full = get_correlation("Std")
+        mdl = hybrid_model(ch_full)
+        term = 2.0
+        dt = 0.25
+        (v, C) = DiffFusion.reference_rate_volatility_and_correlation(
+            [
+                ("EUR", term),
+                ("GBP-EUR", 0.0),
+            ],
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        @test isapprox(v[1], 0.0059616690952, atol=1.0e-14)
+        @test isapprox(v[2], 0.0999883698958, atol=1.0e-13)
+        @test isapprox(C[1,2], 0.1060389153917, atol=1.0e-13)
+        #
+        (v, C) = DiffFusion.reference_rate_volatility_and_correlation(
+            [
+                ("EUR", 1.0),
+                ("EUR", 5.0),
+                ("EUR", 10.0),
+                ("USD", 1.0),
+                ("USD", 5.0),
+                ("USD", 10.0),
+                ("GBP", 1.0),
+                ("GBP", 5.0),
+                ("GBP", 10.0),
+                ("USD-EUR", 0.0),
+                ("GBP-EUR", 0.0),
+            ],
+            ctx, mdl, ch_full, 0.0, dt
+        )
+        v_ref = [
+           0.0063136243172781,
+           0.0062968279461237,
+           0.0063558258150786,
+           0.0084181657563708,
+           0.0083957705948316,
+           0.0084744344201048,
+           0.0084181657563708,
+           0.0083957705948316,
+           0.0084744344201048,
+           0.0999883698957685,
+           0.0999883698957685,
+        ]
+        C_ref = [
+            1.0       0.71153    0.532939   0.18407    0.180252   0.178836   0.18407    0.180252   0.178836   0.102669   0.102669
+            0.71153   1.0        0.965235   0.180252   0.176515   0.175128   0.180252   0.176515   0.175128   0.0961173  0.0961173
+            0.532939  0.965235   1.0        0.178836   0.175128   0.173753   0.178836   0.175128   0.173753   0.0935097  0.0935097
+            0.18407   0.180252   0.178836   1.0        0.71153    0.532939   0.18407    0.180252   0.178836   0.0858348  0.0954544
+            0.180252  0.176515   0.175128   0.71153    1.0        0.965235   0.180252   0.176515   0.175128   0.0899515  0.0934748
+            0.178836  0.175128   0.173753   0.532939   0.965235   1.0        0.178836   0.175128   0.173753   0.0917148  0.0927405
+            0.18407   0.180252   0.178836   0.18407    0.180252   0.178836   1.0        0.71153    0.532939   0.0954544  0.0858348
+            0.180252  0.176515   0.175128   0.180252   0.176515   0.175128   0.71153    1.0        0.965235   0.0934748  0.0899515
+            0.178836  0.175128   0.173753   0.178836   0.175128   0.173753   0.532939   0.965235   1.0        0.0927405  0.0917148
+            0.102669  0.0961173  0.0935097  0.0858348  0.0899515  0.0917148  0.0954544  0.0934748  0.0927405  1.0        0.0996125
+            0.102669  0.0961173  0.0935097  0.0954544  0.0934748  0.0927405  0.0858348  0.0899515  0.0917148  0.0996125  1.0
+        ]
+        @test isapprox(v, v_ref, atol=1.0e-14)
+        @test isapprox(C, C_ref, atol=1.0e-5)
+        # display(v)
+        # display(C)
+    end
+
+end


### PR DESCRIPTION
This PR adds functionality to calculate model-implied volatility and correlation for reference rates. This functionality is supposed to  assist real-world model calibration.   
   - Add reference rate scaling vectors for rates and assets
   - covariance, volatility and correlation calculation