### PR TITLE
Generalise HJM volatility scaling methods

### DIFF
--- a/src/models/rates/GaussianHjmModel.jl
+++ b/src/models/rates/GaussianHjmModel.jl
@@ -39,6 +39,7 @@ end
         factor_alias::AbstractVector
         correlation_holder::Union{CorrelationHolder, Nothing}
         quanto_model::Union{AssetModel, Nothing}
+        scaling_type::BenchmarkTimesScaling
     end
 
 A Gaussian HJM model with piece-wise constant benchmark rate volatility and
@@ -54,6 +55,7 @@ struct GaussianHjmModel <: SeparableHjmModel
     factor_alias::AbstractVector
     correlation_holder::Union{CorrelationHolder, Nothing}
     quanto_model::Union{AssetModel, Nothing}
+    scaling_type::BenchmarkTimesScaling
 end
 
 """
@@ -76,7 +78,7 @@ function gaussian_hjm_model(
     sigma_f::BackwardFlatVolatility,
     correlation_holder::Union{CorrelationHolder, Nothing},
     quanto_model::Union{AssetModel, Nothing},
-    scaling_type::BenchmarkTimesScaling = ForwardRateScaling,
+    scaling_type::BenchmarkTimesScaling = _default_benchmark_time_scaling,
     )
     # Check inputs
     @assert length(delta()) > 0
@@ -117,7 +119,7 @@ function gaussian_hjm_model(
         y0 = y[:,:,k]
     end
     return GaussianHjmModel(alias, delta, chi, sigma_T, y,
-        state_alias, factor_alias, correlation_holder, quanto_model)
+        state_alias, factor_alias, correlation_holder, quanto_model, scaling_type)
 end
 
 """

--- a/src/models/rates/SeparableHjmModel.jl
+++ b/src/models/rates/SeparableHjmModel.jl
@@ -119,6 +119,14 @@ https://ssrn.com/abstract=4638188 for details.
 
 
 """
+    const _default_benchmark_time_scaling = ForwardRateScaling
+
+We specify a default value to allow for backward compatibility in
+seialisation.
+"""
+const _default_benchmark_time_scaling = ForwardRateScaling
+
+"""
     benchmark_times_scaling_forward_rate(chi::AbstractVector, delta::AbstractVector)
 
 Benchmark times volatility scaling matrix ``H [H^f]^{-1} = [H^f H^{-1}]^{-1}``.

--- a/src/serialisation/Models.jl
+++ b/src/serialisation/Models.jl
@@ -8,6 +8,20 @@ serialise(o::Context) = serialise_struct(o)
 
 
 """
+    serialise(o::BenchmarkTimesScaling)
+
+Serialise a BenchmarkTimesScaling enumeration object.
+"""
+function serialise(o::BenchmarkTimesScaling)
+    d = OrderedDict{String, Any}()
+    d["typename"]    = string(typeof(o))
+    d["constructor"] = "BenchmarkTimesScaling"
+    d["enumeration"] = Integer(o)
+    return d
+end
+
+
+"""
     serialise(o::GaussianHjmModel)
 
 Serialise GaussianHjmModel.
@@ -29,6 +43,9 @@ function serialise(o::GaussianHjmModel)
         d["quanto_model"] = serialise(o.quanto_model)
     else
         d["quanto_model"] = serialise_key(o.quanto_model.alias)
+    end
+    if o.scaling_type != _default_benchmark_time_scaling
+        d["scaling_type"] = serialise(o.scaling_type)
     end
     return d
 end

--- a/src/serialisation/RebuildModels.jl
+++ b/src/serialisation/RebuildModels.jl
@@ -29,6 +29,7 @@ function model_parameters(m::GaussianHjmModel)
     else
         d["quanto_model"] = m.quanto_model.alias
     end
+    d["scaling_type"] = m.scaling_type
     # we add another dict layer to allow combining models and ts.
     return Dict(m.alias => d)
 end
@@ -143,6 +144,7 @@ function build_model(
             m_dict["sigma_f"],
             ch,
             quanto_model,
+            m_dict["scaling_type"],
         )
     end
     if m_dict["type"] == LognormalAssetModel

--- a/test/unittests/models/futures/markov_future_model.jl
+++ b/test/unittests/models/futures/markov_future_model.jl
@@ -18,10 +18,22 @@ using Test
         @test DiffFusion.alias(m) == "Std"
         @test DiffFusion.state_alias(m)  == [ "Std_x_1", "Std_x_2", "Std_x_3", ]
         @test DiffFusion.factor_alias(m) == [ "Std_f_1", "Std_f_2", "Std_f_3", ]
+        #
         HHfInv = DiffFusion.benchmark_times_scaling(chi(),delta())
         @test m.hjm_model.sigma_T(1.5) == HHfInv * Diagonal([60., 70., 80.])
         @test m.hjm_model.sigma_T(5.0) == HHfInv * Diagonal([70., 80., 90.])
         @test m.hjm_model.sigma_T(12.0) == HHfInv * Diagonal([80., 90., 90.])
+        #
+        m = DiffFusion.markov_future_model("Std",delta,chi,sigma_F,nothing,nothing,DiffFusion.ZeroRateScaling)
+        A_inv = DiffFusion.benchmark_times_scaling(chi(), delta(), DiffFusion.ZeroRateScaling)
+        @test m.hjm_model.sigma_T(1.5) == A_inv * Diagonal([60., 70., 80.])
+        @test m.hjm_model.sigma_T(5.0) == A_inv * Diagonal([70., 80., 90.])
+        @test m.hjm_model.sigma_T(12.0) == A_inv * Diagonal([80., 90., 90.])
+        #
+        m = DiffFusion.markov_future_model("Std",delta,chi,sigma_F,nothing,nothing,DiffFusion.DiagonalScaling)
+        @test m.hjm_model.sigma_T(1.5) == Diagonal([60., 70., 80.])
+        @test m.hjm_model.sigma_T(5.0) == Diagonal([70., 80., 90.])
+        @test m.hjm_model.sigma_T(12.0) == Diagonal([80., 90., 90.])
         #
         @test_throws AssertionError DiffFusion.markov_future_model("Std", DiffFusion.flat_parameter("", delta()[2:end]), chi, sigma_F, nothing, nothing)
         @test_throws AssertionError DiffFusion.markov_future_model("Std", delta, DiffFusion.flat_parameter("", chi()[2:end]), sigma_F, nothing, nothing)

--- a/test/unittests/models/rates/gaussian_hjm_model.jl
+++ b/test/unittests/models/rates/gaussian_hjm_model.jl
@@ -19,10 +19,23 @@ using LinearAlgebra
         @test DiffFusion.alias(m) == "Std"
         @test DiffFusion.state_alias(m) == [ "Std_x_1", "Std_x_2", "Std_x_3", "Std_s" ]
         @test DiffFusion.factor_alias(m) == [ "Std_f_1", "Std_f_2", "Std_f_3" ]
+        #
         HHfInv = DiffFusion.benchmark_times_scaling(chi(),delta())
         @test m.sigma_T(1.5) == HHfInv * Diagonal([60., 70., 80.])
         @test m.sigma_T(5.0) == HHfInv * Diagonal([70., 80., 90.])
         @test m.sigma_T(12.0) == HHfInv * Diagonal([80., 90., 90.])
+        #
+        m = DiffFusion.gaussian_hjm_model("Std",delta,chi,sigma_f,nothing,nothing,DiffFusion.ZeroRateScaling)
+        A_inv = DiffFusion.benchmark_times_scaling(chi(), delta(), DiffFusion.ZeroRateScaling)
+        @test m.sigma_T(1.5) == A_inv * Diagonal([60., 70., 80.])
+        @test m.sigma_T(5.0) == A_inv * Diagonal([70., 80., 90.])
+        @test m.sigma_T(12.0) == A_inv * Diagonal([80., 90., 90.])
+        #
+        m = DiffFusion.gaussian_hjm_model("Std",delta,chi,sigma_f,nothing,nothing,DiffFusion.DiagonalScaling)
+        @test m.sigma_T(1.5) == Diagonal([60., 70., 80.])
+        @test m.sigma_T(5.0) == Diagonal([70., 80., 90.])
+        @test m.sigma_T(12.0) == Diagonal([80., 90., 90.])
+        #
         @test DiffFusion.correlation_holder(m) == nothing
         #
         @test_throws AssertionError DiffFusion.gaussian_hjm_model("Std", DiffFusion.flat_parameter("", delta()[2:end]), chi, sigma_f, nothing, nothing)

--- a/test/unittests/models/rates/separable_hjm_model.jl
+++ b/test/unittests/models/rates/separable_hjm_model.jl
@@ -39,7 +39,10 @@ using LinearAlgebra
             chi[1]*delta[2] chi[2]*delta[2] chi[3]*delta[2];
             chi[1]*delta[3] chi[2]*delta[3] chi[3]*delta[3];
         ]
-        @test DiffFusion.benchmark_times_scaling(chi,delta) == inv(exp.(-chi_delta))
+        @test DiffFusion.benchmark_times_scaling(chi, delta) == inv(exp.(-chi_delta))
+        @test DiffFusion.benchmark_times_scaling(chi, delta, DiffFusion.ForwardRateScaling) == inv(exp.(-chi_delta))
+        @test DiffFusion.benchmark_times_scaling(chi, delta, DiffFusion.ZeroRateScaling) == inv((1.0 .- exp.(-chi_delta)) ./ chi_delta)
+        @test DiffFusion.benchmark_times_scaling(chi, delta, DiffFusion.DiagonalScaling) == Matrix(I, 3, 3)
     end
 
     @testset "Auxilliary state variable/variance calculation." begin

--- a/test/unittests/serialisation/models.jl
+++ b/test/unittests/serialisation/models.jl
@@ -133,6 +133,94 @@ using YAML
         end
     end
 
+    @testset "GaussianHjmModel with BenchmarkTimesScaling (de-)serialisation." begin
+        models = setup_models(ch_full)
+        ref_dict = Dict(
+            "EUR-USD" => models[2],
+            "One" => ch_one,
+            "Full" => ch_full
+        )
+        #
+        d = OrderedDict(
+            "typename" => "DiffFusion.GaussianHjmModel",
+            "constructor" => "gaussian_hjm_model",
+            "alias" => "USD",
+            "delta" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[1.0], [7.0], [15.0]],
+                ),
+            "chi" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[0.01], [0.1], [0.3]],
+                ),
+            "sigma_f" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatVolatility",
+                "constructor" => "BackwardFlatVolatility",
+                "alias" => "USD",
+                "times" => [0.0],
+                "values" => [[0.005], [0.006], [0.007]]
+                ),
+            "correlation_holder" => "{Full}",
+            "quanto_model" => "nothing",
+            "scaling_type" => OrderedDict{String, Any}(
+                "typename"    => "DiffFusion.BenchmarkTimesScaling",
+                "constructor" => "BenchmarkTimesScaling",
+                "enumeration" => 1,
+            ),
+        )
+        o = DiffFusion.deserialise(d, ref_dict)
+        s = DiffFusion.serialise(o)
+        if VERSION >= v"1.7" # equality tests fail with Julia 1.6
+            @test s == d
+        end
+        #
+        d = OrderedDict(
+            "typename" => "DiffFusion.GaussianHjmModel",
+            "constructor" => "gaussian_hjm_model",
+            "alias" => "EUR",
+            "delta" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[1.0], [10.0]],
+                ),
+            "chi" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatParameter",
+                "constructor" => "BackwardFlatParameter",
+                "alias" => "",
+                "times" => [0.0],
+                "values" => [[0.01], [0.15]],
+                ),
+            "sigma_f" => OrderedDict{String, Any}(
+                "typename" => "DiffFusion.BackwardFlatVolatility",
+                "constructor" => "BackwardFlatVolatility",
+                "alias" => "EUR",
+                "times" => [0.0],
+                "values" => [[0.008], [0.009000000000000001]],
+                ),
+            "correlation_holder" => "{Full}",
+            "quanto_model" => "{EUR-USD}",
+            "quanto_model" => "nothing",
+            "scaling_type" => OrderedDict{String, Any}(
+                "typename"    => "DiffFusion.BenchmarkTimesScaling",
+                "constructor" => "BenchmarkTimesScaling",
+                "enumeration" => 2,
+            ),
+        )
+        o = DiffFusion.deserialise(d, ref_dict)
+        s = DiffFusion.serialise(o)
+        if VERSION >= v"1.7" # equality tests fail with Julia 1.6
+            @test s == d
+        end
+    end
+
     @testset "LognormalAssetModel (de-)serialisation." begin
         models = setup_models(ch_full)
         ref_dict = Dict(

--- a/test/unittests/serialisation/rebuild_models.jl
+++ b/test/unittests/serialisation/rebuild_models.jl
@@ -61,7 +61,7 @@ using Test
         @test length(d) == 1
         @test haskey(d, DiffFusion.alias(usd_model))
         d = d[DiffFusion.alias(usd_model)]
-        for (a, b) in zip(keys(d), ["correlation_holder", "quanto_model", "chi", "sigma_f", "type", "delta", "alias"])
+        for (a, b) in zip(keys(d), ["correlation_holder", "quanto_model", "chi", "sigma_f", "scaling_type", "type", "delta", "alias"])
             @test a == b
         end
         #


### PR DESCRIPTION
This PR generalises the volatility specification for Separable HJM models. We introduce a `BenchmarkTimesScaling` enumeration. This property specifies how state variable volatility is adjusted. We support the following choices:
  - (trivial) no adjustment via `DiagonalScaling`,
  - adjustment for benchmark rate forward rates following Andersen/Piterbarg 2010, Prop. 13.3.2. via `ForwardRateScaling`,
  - adjustment for benchmark rate zero rates (as used [here](https://ssrn.com/abstract=4638188)) via `ZeroRateScaling`.
 