### PR TITLE
Add calibrated real-world model to Examples module

### DIFF
--- a/src/examples/Examples.jl
+++ b/src/examples/Examples.jl
@@ -4,6 +4,7 @@ examples = [
     "g3_1factor_flat",
     "g3_1factor_ts",
     "g3_3factor_ts",
+    "g3_3factor_real_world",
 ]
 
 """

--- a/src/examples/yaml/g3_3factor_real_world.yaml
+++ b/src/examples/yaml/g3_3factor_real_world.yaml
@@ -460,6 +460,10 @@
     - EUR
     - USD
     - GBP
+  swaption_types:
+    - EURIBOR6M_SWPN
+  bermudan_types:
+    - EURIBOR6M_SWPN
   EUR:
     type: VANILLA
     discount_curve_key: EUR:ESTR
@@ -511,3 +515,24 @@
       coupons_per_year: 4
       forward_curve_key: GBP:SONIA
       fixing_key: GBP:SONIA
+  EURIBOR6M_SWPN:
+    setlement_type: CASH
+    #
+    type: VANILLA
+    discount_curve_key: EUR:ESTR
+    fx_key: nothing
+    min_start: 1.0
+    max_start: 10.0
+    min_maturity: 1.0
+    max_maturity: 10.0
+    min_notional: 1.0e+7
+    max_notional: 1.0e+8
+    fixed_leg:
+      coupons_per_year: 1
+      min_rate: 0.01
+      max_rate: 0.04
+    float_leg:
+      coupon_type: SIMPLE
+      coupons_per_year: 2
+      forward_curve_key: EUR:EURIBOR6M
+      fixing_key: EUR:EURIBOR6M

--- a/src/examples/yaml/g3_3factor_real_world.yaml
+++ b/src/examples/yaml/g3_3factor_real_world.yaml
@@ -215,6 +215,10 @@
         - 0.0071
   correlation_holder: "{ch/EUR}"
   quanto_model: "nothing"
+  scaling_type:
+    typename: "DiffFusion.BenchmarkTimesScaling"
+    constructor: "BenchmarkTimesScaling"
+    enumeration: 1 # ZeroRateScaling
 - typename: "DiffFusion.LognormalAssetModel"
   constructor: "lognormal_asset_model"
   alias: "md/USD-EUR"
@@ -274,6 +278,10 @@
         - 0.008
   correlation_holder: "{ch/EUR}"
   quanto_model: "{md/USD-EUR}"
+  scaling_type:
+    typename: "DiffFusion.BenchmarkTimesScaling"
+    constructor: "BenchmarkTimesScaling"
+    enumeration: 1 # ZeroRateScaling
 - typename: "DiffFusion.LognormalAssetModel"
   constructor: "lognormal_asset_model"
   alias: "md/GBP-EUR"
@@ -333,6 +341,10 @@
         - 0.0077
   correlation_holder: "{ch/EUR}"
   quanto_model: "{md/GBP-EUR}"
+  scaling_type:
+    typename: "DiffFusion.BenchmarkTimesScaling"
+    constructor: "BenchmarkTimesScaling"
+    enumeration: 1 # ZeroRateScaling
 #
 - typename: "DiffFusion.SimpleModel"
   constructor: "simple_model"

--- a/src/examples/yaml/g3_3factor_real_world.yaml
+++ b/src/examples/yaml/g3_3factor_real_world.yaml
@@ -1,0 +1,513 @@
+# This example uses a model calibrated to historical return time series
+#
+# Context
+#
+- typename: "DiffFusion.Context"
+  constructor: "Context"
+  alias: "ct/EUR"
+  numeraire:
+    typename: "DiffFusion.NumeraireEntry"
+    constructor: "NumeraireEntry"
+    context_key: "EUR"
+    model_alias: "md/EUR"
+    termstructure_alias:
+      <empty_key> : "yc/EUR:ESTR"
+      ESTR : "yc/EUR:ESTR"
+  rates:
+    EUR:
+      typename: "DiffFusion.RatesEntry"
+      constructor: "RatesEntry"
+      context_key: "EUR"
+      model_alias: "md/EUR"
+      termstructure_alias:
+        <empty_key> : "yc/EUR:ESTR"
+        ESTR : "yc/EUR:ESTR"
+        EURIBOR6M : "yc/EUR:EURIBOR6M"
+    USD:
+      typename: "DiffFusion.RatesEntry"
+      constructor: "RatesEntry"
+      context_key: "USD"
+      model_alias: "md/USD"
+      termstructure_alias:
+        <empty_key> : "yc/USD:XCCY"
+        XCCY : "yc/USD:XCCY"
+        SOFR : "yc/USD:SOFR"
+        LIB3M : "yc/USD:LIB3M"
+    GBP:
+      typename: "DiffFusion.RatesEntry"
+      constructor: "RatesEntry"
+      context_key: "GBP"
+      model_alias: "md/GBP"
+      termstructure_alias:
+        <empty_key> : "yc/GBP:XCCY"
+        XCCY : "yc/GBP:XCCY"
+        SONIA : "yc/GBP:SONIA"
+  assets:
+    USD-EUR:
+      typename: "DiffFusion.AssetEntry"
+      constructor: "AssetEntry"
+      context_key: "USD-EUR"
+      asset_model_alias: "md/USD-EUR"
+      domestic_model_alias: "md/EUR"
+      foreign_model_alias: "md/USD"
+      asset_spot_alias: "pa/USD-EUR"
+      domestic_termstructure_alias:
+        <empty_key> : "yc/EUR:ESTR"
+      foreign_termstructure_alias:
+        <empty_key> : "yc/USD:XCCY"
+    GBP-EUR:
+      typename: "DiffFusion.AssetEntry"
+      constructor: "AssetEntry"
+      context_key: "GBP-EUR"
+      asset_model_alias: "md/GBP-EUR"
+      domestic_model_alias: "md/EUR"
+      foreign_model_alias: "md/GBP"
+      asset_spot_alias: "pa/GBP-EUR"
+      domestic_termstructure_alias:
+        <empty_key> : "yc/EUR:ESTR"
+      foreign_termstructure_alias:
+        <empty_key> : "yc/GBP:XCCY"
+  forward_indices: {}
+  future_indices: {}
+  fixings:
+    EUR:ESTR:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "EUR:ESTR"
+      termstructure_alias: "pa/EUR:ESTR"
+    EUR:EURIBOR6M:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "EUR:EURIBOR6M"
+      termstructure_alias: "pa/EUR:EURIBOR6M"
+    USD:SOFR:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "USD:SOFR"
+      termstructure_alias: "pa/USD:SOFR"
+    USD:LIB3M:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "USD:LIB3M"
+      termstructure_alias: "pa/USD:LIB3M"
+    GBP:SONIA:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "GBP:SONIA"
+      termstructure_alias: "pa/GBP:SONIA"
+    USD-EUR:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "USD-EUR"
+      termstructure_alias: "pa/USD-EUR"
+    GBP-EUR:
+      typename: "DiffFusion.FixingEntry"
+      constructor: "FixingEntry"
+      context_key: "GBP-EUR"
+      termstructure_alias: "pa/GBP-EUR"
+#
+# Correlations
+#
+- typename: "DiffFusion.CorrelationHolder"
+  constructor: "correlation_holder"
+  alias: "ch/EUR"
+  correlations:
+    md/EUR_f_3<>md/USD_f_1: 0.35
+    md/EUR_f_2<>md/GBP-EUR_x: 0.03
+    md/EUR_f_3<>md/USD-EUR_x: 0.08
+    md/GBP_f_3<>md/USD_f_3: 0.75
+    md/EUR_f_1<>md/EUR_f_3: 0.45
+    md/USD_f_1<>md/USD_f_3: 0.45
+    md/USD_f_2<>md/USD_f_3: 0.95
+    md/EUR_f_3<>md/GBP_f_2: 0.75
+    md/GBP_f_1<>md/USD_f_1: 0.55
+    md/EUR_f_1<>md/EUR_f_2: 0.55
+    md/USD_f_1<>md/USD_f_2: 0.55
+    md/EUR_f_2<>md/GBP_f_1: 0.45
+    md/EUR_f_1<>md/GBP-EUR_x: 0.07
+    md/GBP_f_2<>md/USD_f_1: 0.4
+    md/EUR_f_2<>md/GBP_f_2: 0.8
+    md/GBP-EUR_x<>md/GBP_f_3: -0.13
+    md/EUR_f_1<>md/USD_f_1: 0.55
+    md/EUR_f_3<>md/GBP_f_1: 0.37
+    md/EUR_f_2<>md/GBP_f_3: 0.75
+    md/EUR_f_2<>md/USD_f_1: 0.4
+    md/EUR_f_3<>md/USD_f_2: 0.7
+    md/GBP_f_1<>md/GBP_f_2: 0.6
+    md/GBP_f_2<>md/USD_f_2: 0.77
+    md/USD-EUR_x<>md/USD_f_2: -0.1
+    md/GBP_f_2<>md/USD-EUR_x: -0.05
+    md/EUR_f_1<>md/USD_f_2: 0.45
+    md/GBP-EUR_x<>md/USD_f_2: -0.22
+    md/EUR_f_3<>md/USD_f_3: 0.75
+    md/GBP-EUR_x<>md/GBP_f_2: -0.17
+    md/EUR_f_2<>md/EUR_f_3: 0.95
+    md/GBP_f_1<>md/USD-EUR_x: 0.05
+    md/GBP_f_1<>md/GBP_f_3: 0.5
+    md/GBP-EUR_x<>md/USD_f_3: -0.2
+    md/USD-EUR_x<>md/USD_f_3: -0.08
+    md/GBP_f_1<>md/USD_f_2: 0.45
+    md/USD-EUR_x<>md/USD_f_1: -0.15
+    md/GBP_f_3<>md/USD_f_2: 0.72
+    md/GBP_f_2<>md/GBP_f_3: 0.95
+    md/EUR_f_1<>md/GBP_f_3: 0.37
+    md/EUR_f_3<>md/GBP_f_3: 0.75
+    md/GBP-EUR_x<>md/USD-EUR_x: 0.35
+    md/GBP_f_1<>md/USD_f_3: 0.32
+    md/GBP_f_3<>md/USD_f_1: 0.35
+    md/EUR_f_1<>md/USD-EUR_x: 0.25
+    md/GBP-EUR_x<>md/USD_f_1: -0.18
+    md/EUR_f_2<>md/USD-EUR_x: 0.1
+    md/GBP_f_2<>md/USD_f_3: 0.77
+    md/GBP-EUR_x<>md/GBP_f_1: -0.25
+    md/EUR_f_3<>md/GBP-EUR_x: 0.02
+    md/EUR_f_1<>md/GBP_f_2: 0.47
+    md/EUR_f_2<>md/USD_f_3: 0.75
+    md/EUR_f_2<>md/USD_f_2: 0.75
+    md/EUR_f_1<>md/GBP_f_1: 0.67
+    md/EUR_f_1<>md/USD_f_3: 0.35
+    md/GBP_f_3<>md/USD-EUR_x: -0.07
+  sep: "<>"
+#
+# Models
+#
+- typename: "DiffFusion.GaussianHjmModel"
+  constructor: "gaussian_hjm_model"
+  alias: "md/EUR"
+  delta:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 1.0
+      -
+        - 10.0
+      -
+        - 20.0
+  chi:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.01
+      -
+        - 0.5
+      -
+        - 0.8
+  sigma_f:
+    typename: "DiffFusion.BackwardFlatVolatility"
+    constructor: "BackwardFlatVolatility"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.006
+      -
+        - 0.0068
+      -
+        - 0.0071
+  correlation_holder: "{ch/EUR}"
+  quanto_model: "nothing"
+- typename: "DiffFusion.LognormalAssetModel"
+  constructor: "lognormal_asset_model"
+  alias: "md/USD-EUR"
+  sigma_x:
+    typename: "DiffFusion.BackwardFlatVolatility"
+    constructor: "BackwardFlatVolatility"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.09
+  correlation_holder: "{ch/EUR}"
+  quanto_model: "nothing"
+#
+- typename: "DiffFusion.GaussianHjmModel"
+  constructor: "gaussian_hjm_model"
+  alias: "md/USD"
+  delta:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 1.0
+      -
+        - 10.0
+      -
+        - 20.0
+  chi:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.01
+      -
+        - 0.3
+      -
+        - 0.6
+  sigma_f:
+    typename: "DiffFusion.BackwardFlatVolatility"
+    constructor: "BackwardFlatVolatility"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.007
+      -
+        - 0.0085
+      -
+        - 0.008
+  correlation_holder: "{ch/EUR}"
+  quanto_model: "{md/USD-EUR}"
+- typename: "DiffFusion.LognormalAssetModel"
+  constructor: "lognormal_asset_model"
+  alias: "md/GBP-EUR"
+  sigma_x:
+    typename: "DiffFusion.BackwardFlatVolatility"
+    constructor: "BackwardFlatVolatility"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.075
+  correlation_holder: "{ch/EUR}"
+  quanto_model: "nothing"
+#
+- typename: "DiffFusion.GaussianHjmModel"
+  constructor: "gaussian_hjm_model"
+  alias: "md/GBP"
+  delta:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 1.0
+      -
+        - 10.0
+      -
+        - 20.0
+  chi:
+    typename: "DiffFusion.BackwardFlatParameter"
+    constructor: "BackwardFlatParameter"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.01
+      -
+        - 0.2
+      -
+        - 0.4
+  sigma_f:
+    typename: "DiffFusion.BackwardFlatVolatility"
+    constructor: "BackwardFlatVolatility"
+    alias: ""
+    times:
+      - 0.0
+    values:
+      -
+        - 0.0078
+      -
+        - 0.0086
+      -
+        - 0.0077
+  correlation_holder: "{ch/EUR}"
+  quanto_model: "{md/GBP-EUR}"
+#
+- typename: "DiffFusion.SimpleModel"
+  constructor: "simple_model"
+  alias: "md/G3-EUR"
+  models:
+    - "{md/EUR}"
+    - "{md/USD-EUR}"
+    - "{md/USD}"
+    - "{md/GBP-EUR}"
+    - "{md/GBP}"
+#
+# Yield curves
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/EUR:ESTR"
+  rate: 0.0297
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/EUR:EURIBOR6M"
+  rate: 0.0316
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/USD:SOFR"
+  rate: 0.0358
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/USD:XCCY"
+  rate: 0.0365
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/USD:LIB3M"
+  rate: 0.0374
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/GBP:SONIA"
+  rate: 0.0371
+#
+- typename: "DiffFusion.FlatForward"
+  constructor: "FlatForward"
+  alias: "yc/GBP:XCCY"
+  rate: 0.0376
+# Fixings
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/USD:SOFR"
+  times:
+    -  0.00
+  values:
+    - 0.0455
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/USD:LIB3M"
+  times:
+    -  0.00
+  values:
+    - 0.0486
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/EUR:ESTR"
+  times:
+    -  0.00
+  values:
+    - 0.0240
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/EUR:EURIBOR6M"
+  times:
+    -  0.00
+  values:
+    - 0.0308
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/GBP:SONIA"
+  times:
+    -  0.00
+  values:
+    - 0.0308
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/USD-EUR"
+  times:
+    -  0.00
+  values:
+    - 0.93
+#
+- typename: "DiffFusion.ForwardFlatParameter"
+  constructor: "forward_flat_parameter"
+  alias: "pa/GBP-EUR"
+  times:
+    - 0.00
+  values:
+    - 1.18
+#
+# Config
+#
+- alias: "config/simulation"
+  simulation_times:
+    start: 0.0
+    step: 1.0
+    stop: 10.0
+  n_paths: 8192
+  with_progress_bar: true
+  seed: 42
+  path_interpolation: true
+- alias: "config/instruments"
+  seed: 123456
+  obs_times:
+    start: 0.0
+    step: 1.0
+    stop: 10.0
+  with_progress_bar: true
+  discount_curve_key: "EUR:ESTR"
+  swap_types:
+    - EUR
+    - USD
+    - GBP
+  EUR:
+    type: VANILLA
+    discount_curve_key: EUR:ESTR
+    fx_key: nothing
+    min_maturity: 1.0
+    max_maturity: 10.0
+    min_notional: 1.0e+7
+    max_notional: 1.0e+8
+    fixed_leg:
+      coupons_per_year: 1
+      min_rate: 0.01
+      max_rate: 0.04
+    float_leg:
+      coupon_type: SIMPLE
+      coupons_per_year: 2
+      forward_curve_key: EUR:EURIBOR6M
+      fixing_key: EUR:EURIBOR6M
+  USD:
+    type: VANILLA
+    discount_curve_key: USD:XCCY
+    fx_key: USD-EUR
+    min_maturity: 1.0
+    max_maturity: 10.0
+    min_notional: 1.0e+7
+    max_notional: 1.0e+8
+    fixed_leg:
+      coupons_per_year: 4
+      min_rate: 0.01
+      max_rate: 0.04
+    float_leg:
+      coupon_type: COMPOUNDED
+      coupons_per_year: 4
+      forward_curve_key: USD:SOFR
+      fixing_key: USD:SOFR
+  GBP:
+    type: VANILLA
+    discount_curve_key: GBP:XCCY
+    fx_key: GBP-EUR
+    min_maturity: 1.0
+    max_maturity: 10.0
+    min_notional: 1.0e+7
+    max_notional: 1.0e+8
+    fixed_leg:
+      coupons_per_year: 4
+      min_rate: 0.01
+      max_rate: 0.04
+    float_leg:
+      coupon_type: COMPOUNDED
+      coupons_per_year: 4
+      forward_curve_key: GBP:SONIA
+      fixing_key: GBP:SONIA


### PR DESCRIPTION
This PR adds a hybrid model to the Examples module. The hybrid model is calibrated to match volatilities and correlations observed from historical time series of interest rates and exchange rates.

Calibration methodology is implemented and documented [here](https://github.com/sschlenkrich/DiffFusionExamples.jl/tree/main/ModelCalibration). Historical time series data are documented [here](https://github.com/sschlenkrich/MarketData).