### PR TITLE
Add permissions to Documentation workflow

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     permissions:
       contents: write
+      id-token: write
+      pages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR should fix recently failing deployment of documentation on github pages.