### PR TITLE
Switch CI action runtests to julia-actions

### DIFF
--- a/.github/workflows/CI_componenttests.yml
+++ b/.github/workflows/CI_componenttests.yml
@@ -30,6 +30,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: sschlenkrich/julia-runtest@with_test_arg_v4
+      - uses: julia-actions/julia-runtest@v1
         with:
-          test_arg: 'componenttests/componenttests_all.jl'
+          test_args: 'componenttests/componenttests_all.jl'

--- a/.github/workflows/CI_unittests.yml
+++ b/.github/workflows/CI_unittests.yml
@@ -33,6 +33,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: sschlenkrich/julia-runtest@with_test_arg_v4
+      - uses: julia-actions/julia-runtest@v1
         with:
-          test_arg: 'unittests/unittests_all.jl'
+          test_args: 'unittests/unittests_all.jl'

--- a/.github/workflows/CI_unittests_nightly.yml
+++ b/.github/workflows/CI_unittests_nightly.yml
@@ -29,6 +29,6 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: sschlenkrich/julia-runtest@with_test_arg_v4
+      - uses: julia-actions/julia-runtest@v1
         with:
-          test_arg: 'unittests/unittests_all.jl'
+          test_args: 'unittests/unittests_all.jl'

--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -32,9 +32,9 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: sschlenkrich/julia-runtest@with_test_arg_v4
+      - uses: julia-actions/julia-runtest@v1
         with:
-          test_arg: 'unittests/unittests_all.jl'
+          test_args: 'unittests/unittests_all.jl'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
This PR switches back to julia-actions/julia-runtest after implementation of `test_args` parameter.