### PR TITLE
Add unittests to increase test coverage

### DIFF
--- a/test/unittests/analytics/valuations.jl
+++ b/test/unittests/analytics/valuations.jl
@@ -37,6 +37,8 @@ using ForwardDiff
     sim = DiffFusion.simple_simulation(fx_model, ch, times, n_paths, with_progress_bar = false)
     path = DiffFusion.path(sim, ts_list, context, DiffFusion.LinearPathInterpolation)
 
+    sim_func(model, ch) = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false)
+    make_regression(C, O) = DiffFusion.polynomial_regression(C, O, 1)
 
     @testset "Delta calculation" begin
         @info "Start testing AD Deltas..."
@@ -76,7 +78,6 @@ using ForwardDiff
     @testset "Vega calculation" begin
         @info "Start testing AD Vegas..."
         model = DiffFusion.simple_model("Std", [fx_model])
-        sim_func(model, ch) = DiffFusion.simple_simulation(model, ch, times, n_paths, with_progress_bar = false)
         #
         payoffs = [ DiffFusion.Asset(2.0, "EUR-USD")]
         model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
@@ -94,6 +95,66 @@ using ForwardDiff
         @test isapprox(g2, g3, atol=1.0e-10)
         @info "Finished."
         # println(g1)
+    end
+
+    @testset "Zero model price and delta/vega calculation" begin
+        # also capture case with non-trivial correlation
+        ch = DiffFusion.correlation_holder("Two")
+        DiffFusion.set_correlation!(ch, "EUR-USD_x", "GBP-USD_x", 0.3)
+        sigma_fx = DiffFusion.flat_volatility("EUR-USD", 0.15)
+        fx_model = DiffFusion.lognormal_asset_model("EUR-USD", sigma_fx, ch, nothing)
+        sim = DiffFusion.simple_simulation(fx_model, ch, times, n_paths, with_progress_bar = false)
+        path = DiffFusion.path(sim, ts_list, context, DiffFusion.LinearPathInterpolation)
+        #
+        payoffs = [ ]
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        @test model_price == 0.0
+        #
+        @info "Testing Zero AD Deltas..."
+        #
+        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, "USD")
+        @test v == model_price
+        #
+        model_price = DiffFusion.model_price(payoffs, path, nothing, nothing)
+        (v, g) = DiffFusion.model_price_and_deltas(payoffs, path, nothing, nothing)
+        @test v == model_price
+        #
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", Zygote)
+        (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", ForwardDiff)
+        (v3, g3, l3) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, "USD", FiniteDifferences)
+        @test v1 == model_price
+        @test v2 == model_price
+        @test v2 == model_price
+        # @test isapprox(g1, g2, atol=1.0e-12)
+        # @test isapprox(g2, g3, atol=1.0e-10)
+        #
+        model_price = DiffFusion.model_price(payoffs, path, nothing, nothing)
+        (v1, g1, l1) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, nothing, Zygote)
+        (v2, g2, l2) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, nothing, ForwardDiff)
+        (v3, g3, l3) = DiffFusion.model_price_and_deltas_vector(payoffs, path, nothing, nothing, FiniteDifferences)
+        @test v1 == model_price
+        @test v2 == model_price
+        @test v3 == model_price
+        # @test isapprox(g1, g2, atol=1.0e-12)
+        # @test isapprox(g2, g3, atol=1.0e-9)
+        #
+        @info "Testing Zero AD Vegas..."
+        #
+        model = DiffFusion.simple_model("Std", [fx_model])
+        #
+        (v, g) = DiffFusion.model_price_and_vegas(payoffs, model, sim_func, ts_list, context, nothing, "USD")
+        @test v == model_price
+        #
+        model_price = DiffFusion.model_price(payoffs, path, nothing, "USD")
+        (v1, g1, l1) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", Zygote)
+        (v2, g2, l2) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", ForwardDiff)
+        (v3, g3, l3) = DiffFusion.model_price_and_vegas_vector(payoffs, model, sim_func, ts_list, context, nothing, "USD", FiniteDifferences)
+        @test v1 == model_price
+        @test v2 == model_price
+        @test v3 == model_price
+        # @test isapprox(g1, g2, atol=1.0e-12)
+        # @test isapprox(g2, g3, atol=1.0e-10)
     end
 
 end

--- a/test/unittests/products/rates_coupons.jl
+++ b/test/unittests/products/rates_coupons.jl
@@ -47,6 +47,20 @@ using Test
         @test string(DiffFusion.amount(C)) == "(Idx(EURIBOR, -0.50) + 0.0100) * 1.0000"
     end
 
+    @testset "SimpleRate option test" begin
+        C = DiffFusion.SimpleRateCoupon(1.8, 2.0, 3.0, 3.2, 1.0, "EUR6M", nothing, nothing)
+        O = DiffFusion.OptionletCoupon(C, 0.01, +1.0)  # expiry_time from CompoundedRateCoupon
+        @test DiffFusion.pay_time(O) == 3.2
+        @test DiffFusion.year_fraction(O) == 1.0
+        @test string(DiffFusion.amount(O)) == "Max(1.0000 * (L(EUR6M, 1.80; 2.00, 3.00) - 0.0100), 0.0000) * 1.0000"
+        @test string(DiffFusion.expected_amount(O, 0.5)) == "Caplet(L(EUR6M, 0.50; 2.00, 3.00), 0.0100; 1.80) * 1.0000"
+        @test string(DiffFusion.expected_amount(O, 1.0)) == "Caplet(L(EUR6M, 1.00; 2.00, 3.00), 0.0100; 1.80) * 1.0000"
+        @test string(DiffFusion.expected_amount(O, 2.5)) == "Max(1.0000 * (L(EUR6M, 1.80; 2.00, 3.00) - 0.0100), 0.0000) * 1.0000"
+        @test string(DiffFusion.expected_amount(O, 3.0)) == "Max(1.0000 * (L(EUR6M, 1.80; 2.00, 3.00) - 0.0100), 0.0000) * 1.0000"
+        # println(string(DiffFusion.amount(O)))
+        # println(string(DiffFusion.expected_amount(O, 0.0)))
+    end
+
     @testset "CompoundedRateCoupon test" begin
         period_times = 1.0:0.1:2.0
         period_year_fractions = period_times[2:end] - period_times[1:end-1]
@@ -88,6 +102,13 @@ using Test
         @test string(DiffFusion.expected_amount(C, 0.05)) == string(DiffFusion.amount(C))
         @test string(DiffFusion.expected_amount(C, 0.1)) == string(DiffFusion.amount(C))
         @test string(DiffFusion.expected_amount(C, 0.2)) == string(DiffFusion.amount(C))
+        #
+        period_times = [-2.0, -1.5, -1.0]
+        period_year_fractions = [ 0.5, 0.5 ]
+        C = DiffFusion.CompoundedRateCoupon(period_times, period_year_fractions, period_times[end], "USD:SOFR", "SOFR", 0.02)
+        @test string(DiffFusion.amount(C)) == "((((1.0000 + Idx(SOFR, -2.00) * 0.5000) * (1.0000 + Idx(SOFR, -1.50) * 0.5000) - 1.0000) / 1.0000) + 0.0200) * 1.0000"
+        @test string(DiffFusion.expected_amount(C, 0.0)) == string(DiffFusion.amount(C))
+        #
         # println(string(DiffFusion.amount(C)))
         # println(string(DiffFusion.expected_amount(C, 0.0)))
     end


### PR DESCRIPTION
With this PR we add test cases to cover implmentation edge cases:
- Add PathMethods tests
- Add interest rate coupon payoffs tests
- Add serialisation tests for edge cases
- Add edge cases tests for reference rate volatlity and correlation
- Add additional Valuations tests
