### PR TITLE
BenchmarkTimesScaling to GaussianHjmModel calibration

### DIFF
--- a/src/models/rates/SwapRateCalibration.jl
+++ b/src/models/rates/SwapRateCalibration.jl
@@ -11,6 +11,7 @@
         yts::YieldTermstructure;
         max_iter::Integer = 5,
         volatility_regularisation::ModelValue = 0.0,
+        scaling_type::BenchmarkTimesScaling = _default_benchmark_time_scaling,
         )
 
 Calibrate a model with flat volatilities and mean reversion
@@ -25,6 +26,7 @@ function gaussian_hjm_model(
     yts::YieldTermstructure;
     max_iter::Integer = 5,
     volatility_regularisation::ModelValue = 0.0,
+    scaling_type::BenchmarkTimesScaling = _default_benchmark_time_scaling,
     )
     #
     # check inputs first
@@ -50,7 +52,7 @@ function gaussian_hjm_model(
         chi_ = vcat([exp_x[1]], exp_x[1] .+ d_chi)   #  ensure monotonicity
         chi = flat_parameter(chi_)
         sigma_f = backward_flat_volatility("", [0.0], reshape(exp_x[d+1:end], (:,1)) )
-        return gaussian_hjm_model(alias, delta, chi, sigma_f, ch, nothing)
+        return gaussian_hjm_model(alias, delta, chi, sigma_f, ch, nothing, scaling_type)
     end
     #
     x0 = log.(vcat(
@@ -104,6 +106,7 @@ end
         yts::YieldTermstructure;
         max_iter::Integer = 5,
         volatility_regularisation::ModelValue = 0.0,
+        scaling_type::BenchmarkTimesScaling = _default_benchmark_time_scaling,
         )
 
 
@@ -123,6 +126,7 @@ function gaussian_hjm_model(
     yts::YieldTermstructure;
     max_iter::Integer = 5,
     volatility_regularisation::ModelValue = 0.0,
+    scaling_type::BenchmarkTimesScaling = _default_benchmark_time_scaling,
     )
     #
     # check inputs first
@@ -154,12 +158,12 @@ function gaussian_hjm_model(
         )
         sigma_f = backward_flat_volatility("", m.sigma_T.sigma_f.times, sigma_f_)
         # TODO: use low-level incremental model construction
-        return gaussian_hjm_model(alias, delta, chi, sigma_f, ch, nothing)
+        return gaussian_hjm_model(alias, delta, chi, sigma_f, ch, nothing, scaling_type)
     end
     #
     x0 = log.(mean(swap_rate_volatilities) * ones(d))
     σ0 = backward_flat_volatility("", option_times, zeros((d, length(option_times))))
-    m0 = gaussian_hjm_model(alias, delta, chi, σ0, ch, nothing)
+    m0 = gaussian_hjm_model(alias, delta, chi, σ0, ch, nothing, scaling_type)
     X = zeros( (length(state_alias(m0)), 1) )
     SX = model_state(X, m0)
     function obj_F(x::AbstractVector, m::GaussianHjmModel, idx::Integer)

--- a/test/componenttests/calibration/swap_rate_calibration.jl
+++ b/test/componenttests/calibration/swap_rate_calibration.jl
@@ -4,8 +4,8 @@ using DiffFusion
 using Test
 
 @testset "Test Gaussian HJM model calibration." begin
-    
-    @testset "Test flat parameter calibration." begin
+
+    @testset "Test flat parameter calibration, ForwardRateScaling." begin
         yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
         option_times = [ 1.0, 2.0, 5.0, 10.0 ]
         swap_maturities = [ 2.0, 10.0, 20.0 ]
@@ -40,11 +40,12 @@ using Test
             yts,
             max_iter = 5,
             volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -13.6e-4)
         @test all(res.fit .<   8.2e-4)
         println("")
-        println("Global model calibration results 1:")
+        println("Global model calibration results 1, ForwardRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f)
         display(res.fit * 1e+4)
@@ -69,11 +70,12 @@ using Test
             vols[op_idx, sw_idx],
             yts, max_iter = 5,
             volatility_regularisation = 0.3,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -18.9e-4)
         @test all(res.fit .<  13.5e-4)
         println("")
-        println("Global model calibration results 2:")
+        println("Global model calibration results 2, ForwardRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f)
         display(res.fit * 1e+4)
@@ -99,17 +101,18 @@ using Test
             yts,
             max_iter = 5,
             volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -12.2e-4)
         @test all(res.fit .<  12.4e-4)
         println("")
-        println("Global model calibration results 3:")
+        println("Global model calibration results 3, ForwardRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f)
         display(res.fit * 1e+4)
     end
 
-    @testset "Test piece-wise flat vol calibration." begin
+    @testset "Test piece-wise flat vol calibration, ForwardRateScaling." begin
         yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
         option_times = [ 1.0, 2.0, 5.0, 10.0 ]
         swap_maturities = [ 2.0, 10.0, 20.0 ]
@@ -149,11 +152,12 @@ using Test
             yts,
             max_iter = 5,
             volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -6.8e-4)
         @test all(res.fit .<  7.4e-4)
         println("")
-        println("Piece-wise model calibration results 1:")
+        println("Piece-wise model calibration results 1, ForwardRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f.times)
         display(res.model.sigma_T.sigma_f.values)
@@ -184,11 +188,12 @@ using Test
             vols[op_idx, sw_idx],
             yts, max_iter = 5,
             volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -7.4e-4)
         @test all(res.fit .<  6.8e-4)
         println("")
-        println("Piece-wise model calibration results 2:")
+        println("Piece-wise model calibration results 2, ForwardRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f.times)
         display(res.model.sigma_T.sigma_f.values)
@@ -220,11 +225,245 @@ using Test
             yts,
             max_iter = 5,
             volatility_regularisation = 0.01,
+            scaling_type = DiffFusion.ForwardRateScaling,
         )
         @test all(res.fit .> -0.1e-4)
         @test all(res.fit .<  0.1e-4)
         println("")
-        println("Piece-wise model calibration results 3:")
+        println("Piece-wise model calibration results 3, ForwardRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f.times)
+        display(res.model.sigma_T.sigma_f.values)
+        display(res.fit * 1e+4)
+    end
+
+
+    @testset "Test flat parameter calibration, ZeroRateScaling." begin
+        yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
+        option_times = [ 1.0, 2.0, 5.0, 10.0 ]
+        swap_maturities = [ 2.0, 10.0, 20.0 ]
+        #
+        c = 0.80
+        ch = DiffFusion.correlation_holder("Full")
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_2", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "EUR_f_3", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_3", c)
+        #
+        option_times = [ 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 15.0, 20.0 ]
+        swap_maturities = [ 1.0, 2.0, 5.0, 10.0, 20.0 ]
+        #
+        vols = [
+            104.1   109.7   108.9   104.4   95.5
+            103.9   106.3   104.5   101.3   92.6
+            103.4   104.6   101.2    98.1   89.2
+             98.5    98.4    94.4    89.7   80.7
+             92.4    92.2    88.0    83.3   73.9
+             86.5    86.6    81.5    76.4   66.5
+             78.6    78.2    73.1    67.5   58.1
+             73.2    73.2    67.7    62.0   52.7
+            ] * 1.0e-4
+        op_idx = [ 2, 4, 6 ]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts,
+            max_iter = 5,
+            volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -21.2e-4)
+        @test all(res.fit .<  16.5e-4)
+        println("")
+        println("Global model calibration results 1, ZeroRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f)
+        display(res.fit * 1e+4)
+        #
+        vols = [
+            142.0   146.6   139.6   129.3   125.8
+            139.1   138.4   128.8   119.3   116.1
+            133.2   131.3   120.6   110.9   107.4
+            118.0   116.1   106.6    98.6    95.2
+            107.2   105.7    97.7    91.1    87.1
+             97.7    96.1    89.7    85.2    80.4
+             88.8    87.7    83.4    80.0    74.1
+             81.4    80.6    77.7    74.4    68.1
+            ]  * 1.0e-4
+        op_idx = [ 2, 4, 6 ]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts, max_iter = 5,
+            volatility_regularisation = 0.3,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -30.8e-4)
+        @test all(res.fit .<  24.9e-4)
+        println("")
+        println("Global model calibration results 2, ZeroRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f)
+        display(res.fit * 1e+4)
+        #
+        vols = [
+            129.1   130.7   119.5   106.5   92.9
+            127.0   124.2   113.7   101.3   89.4
+            119.7   115.2   107.5    96.3   85.5
+            106.6   103.4    97.3    89.0   79.4
+             96.2    93.9    89.5    82.6   73.6
+             86.0    83.9    80.0    74.5   66.3
+             74.2    71.9    68.9    64.6   58.4
+             65.3    64.4    61.5    57.9   53.2
+            ] * 1.0e-4
+        op_idx = [ 2, 4, 6 ]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts,
+            max_iter = 5,
+            volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -23.7e-4)
+        @test all(res.fit .<  20.9e-4)
+        println("")
+        println("Global model calibration results 3, ZeroRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f)
+        display(res.fit * 1e+4)
+    end
+
+    @testset "Test piece-wise flat vol calibration, ZeroRateScaling." begin
+        yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
+        option_times = [ 1.0, 2.0, 5.0, 10.0 ]
+        swap_maturities = [ 2.0, 10.0, 20.0 ]
+        #
+        c = 0.80
+        ch = DiffFusion.correlation_holder("Full")
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_2", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "EUR_f_3", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_3", c)
+        #
+        option_times = [ 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 15.0, 20.0 ]
+        swap_maturities = [ 1.0, 2.0, 5.0, 10.0, 20.0 ]
+        #
+        delta = DiffFusion.flat_parameter([ 2., 5., 10. ])
+        chi = DiffFusion.flat_parameter([ 0.15, 0.45, 0.85 ])
+        #
+        vols = [
+            104.1   109.7   108.9   104.4   95.5
+            103.9   106.3   104.5   101.3   92.6
+            103.4   104.6   101.2    98.1   89.2
+             98.5    98.4    94.4    89.7   80.7
+             92.4    92.2    88.0    83.3   73.9
+             86.5    86.6    81.5    76.4   66.5
+             78.6    78.2    73.1    67.5   58.1
+             73.2    73.2    67.7    62.0   52.7
+            ] * 1.0e-4
+        op_idx = [ 1, 3, 4, 5, 6, 7, 8 ]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            delta,
+            chi,
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts,
+            max_iter = 5,
+            volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -2.8e-4)
+        @test all(res.fit .<  2.9e-4)
+        println("")
+        println("Piece-wise model calibration results 1, ZeroRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f.times)
+        display(res.model.sigma_T.sigma_f.values)
+        display(res.fit * 1e+4)
+        #
+        delta = DiffFusion.flat_parameter([ 2., 5., 10. ])
+        chi = DiffFusion.flat_parameter([ 0.15, 0.45, 0.85 ])
+        #
+        vols = [
+            142.0   146.6   139.6   129.3   125.8
+            139.1   138.4   128.8   119.3   116.1
+            133.2   131.3   120.6   110.9   107.4
+            118.0   116.1   106.6    98.6    95.2
+            107.2   105.7    97.7    91.1    87.1
+             97.7    96.1    89.7    85.2    80.4
+             88.8    87.7    83.4    80.0    74.1
+             81.4    80.6    77.7    74.4    68.1
+            ] * 1.0e-4
+        op_idx = [ 1, 3, 4, 5, 6, 7, 8 ]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            delta,
+            chi,
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts, max_iter = 5,
+            volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -3.3e-4)
+        @test all(res.fit .<  3.4e-4)
+        println("")
+        println("Piece-wise model calibration results 2, ZeroRateScaling:")
+        display(res.model.chi)
+        display(res.model.sigma_T.sigma_f.times)
+        display(res.model.sigma_T.sigma_f.values)
+        display(res.fit * 1e+4)
+        #
+        delta = DiffFusion.flat_parameter([ 2., 5., 10. ])
+        chi = DiffFusion.flat_parameter([ 0.10, 0.30, 0.95 ])
+        #
+        vols = [
+            129.1   130.7   119.5   106.5   92.9
+            127.0   124.2   113.7   101.3   89.4
+            119.7   115.2   107.5    96.3   85.5
+            106.6   103.4    97.3    89.0   79.4
+             96.2    93.9    89.5    82.6   73.6
+             86.0    83.9    80.0    74.5   66.3
+             74.2    71.9    68.9    64.6   58.4
+             65.3    64.4    61.5    57.9   53.2
+            ] * 1.0e-4
+        op_idx = [ 1, 4, 5, 6, 7, 8]
+        sw_idx = [ 2, 3, 4 ]
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            delta,
+            chi,
+            ch,
+            option_times[op_idx],
+            swap_maturities[sw_idx],
+            vols[op_idx, sw_idx],
+            yts,
+            max_iter = 5,
+            volatility_regularisation = 0.1,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -2.2e-4)
+        @test all(res.fit .<  1.2e-4)
+        println("")
+        println("Piece-wise model calibration results 3, ZeroRateScaling:")
         display(res.model.chi)
         display(res.model.sigma_T.sigma_f.times)
         display(res.model.sigma_T.sigma_f.values)

--- a/test/unittests/models/rates/swap_rate_calibration.jl
+++ b/test/unittests/models/rates/swap_rate_calibration.jl
@@ -132,4 +132,73 @@ using Test
         # display(res.fit * 1e+4)
     end
 
+
+    @testset "Test flat parameter calibration with ZeroRateScaling." begin
+        yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
+        option_times = [ 1.0, 2.0, 5.0, 10.0 ]
+        swap_maturities = [ 2.0, 10.0, 20.0 ]
+        #
+        ch = DiffFusion.correlation_holder("Full")
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_2", 0.70)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "EUR_f_3", 0.90)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_3", 0.50)
+        # flat implied vol surface
+        implied_vols = 0.01 * ones((length(option_times), length(swap_maturities)))
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            ch,
+            option_times,
+            swap_maturities,
+            implied_vols,
+            yts,
+            max_iter = 5,
+            volatility_regularisation = 0.30,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        @test all(res.fit .> -5.7e-4)
+        @test all(res.fit .<  5.2e-4)
+        # display(res.model.chi)
+        # display(res.model.sigma_T.sigma_f)
+        # display(res.fit * 1e+4)
+    end
+
+
+    @testset "Test piece-wise flat vol calibration with ZeroRateScaling." begin
+        yts = DiffFusion.zero_curve("", [0.0, 10.0], [0.03, 0.03])
+        option_times = [ 1.0, 2.0, 5.0, 10.0 ]
+        swap_maturities = [ 2.0, 10.0, 20.0 ]
+        #
+        c = 0.80
+        ch = DiffFusion.correlation_holder("Full")
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_2", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_2", "EUR_f_3", c)
+        DiffFusion.set_correlation!(ch, "EUR_f_1", "EUR_f_3", c)
+        #
+        delta = DiffFusion.flat_parameter([ 2., 10., 20. ])
+        chi = DiffFusion.flat_parameter([ 0.01, 0.10, 0.33 ])
+
+        # flat implied vol surface
+        implied_vols = 0.01 * ones((length(option_times), length(swap_maturities)))
+        res = DiffFusion.gaussian_hjm_model(
+            "EUR",
+            delta,
+            chi,
+            ch,
+            option_times,
+            swap_maturities,
+            implied_vols,
+            yts, max_iter = 5,
+            volatility_regularisation = 0.10,
+            scaling_type = DiffFusion.ZeroRateScaling,
+        )
+        # display(res)
+        @test all(res.fit .> -2.7e-4)
+        @test all(res.fit .<  2.0e-4)
+        # display(res.model.chi)
+        # display(res.model.sigma_T.sigma_f.times)
+        # display(res.model.sigma_T.sigma_f.values)
+        # display(res.fit * 1e+4)
+    end
+
+
 end


### PR DESCRIPTION
This PR adds a scaling_type parameter to the GaussianHjmModel calibration. This makes available
 - ForwardRateScaling (default, see Andersen/Piterbarg 2010),
 - ZeroRateScaling (our approach)
 - DiagonalScaling (G2++, see Brigo/Mercurio 2007).