### PR TITLE
Update AD to use DifferentiationInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "DiffFusion"
 uuid = "be7e520c-a8fa-4f26-8f65-6d6d1049182e"
-authors = ["Sebastian Schlenkrich <sebastian.schlenkrich@frame-consult.de> and contributors"]
 version = "0.7.1"
+authors = ["Sebastian Schlenkrich <sebastian.schlenkrich@frame-consult.de> and contributors"]
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
@@ -33,6 +34,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 ChainRulesCore = "1"
 DelimitedFiles = "1"
+DifferentiationInterface = "0.7.12"
 Distributions = "0.25"
 FiniteDifferences = "0.12"
 ForwardDiff = "0.10, 1"

--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -130,14 +130,11 @@ module Examples
     include("examples/Products.jl")
 end # module
 
-# Zygote is broken with Julia 1.12; we exclude Zygote until it is fixed
-if VERSION < v"1.12"
-    const _use_zygote = true
-else
-    const _use_zygote = false
-end
+# Zygote is broken with Julia 1.12; we may exclude Zygote at some point
+const _use_zygote = true
 if _use_zygote
     include("analytics/ValuationsViaZygote.jl")
+    include("chainrules/control.jl")
     include("chainrules/models.jl")
     include("chainrules/termstructures.jl")
     include("chainrules/simulations.jl")

--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -1,11 +1,8 @@
 module DiffFusion
 
-using ChainRulesCore
 using DelimitedFiles
 using Distributed
 using Distributions
-using FiniteDifferences
-using ForwardDiff
 using Interpolations
 using LinearAlgebra
 using LsqFit
@@ -19,7 +16,13 @@ using SharedArrays
 using Sobol
 using SparseArrays
 using StatsBase
-using Zygote
+
+# AD modules
+using ChainRulesCore
+using DifferentiationInterface
+using FiniteDifferences: FiniteDifferences
+using ForwardDiff: ForwardDiff
+using Zygote: Zygote
 
 import Base.length
 import Base.string

--- a/src/analytics/Valuations.jl
+++ b/src/analytics/Valuations.jl
@@ -66,7 +66,7 @@ end
         path_obj::Path,
         pay_time::Union{ModelTime, Nothing} = nothing,
         discount_curve_key::Union{String,Nothing} = nothing,
-        ad_module::Module = ForwardDiff,
+        ad_module::Union{Module, DifferentiationInterface.AbstractADType} = ForwardDiff,
         )
 
 Calculate model price and curve sensitivities. Sensitivities are
@@ -88,7 +88,7 @@ function model_price_and_deltas(
     path_obj::Path,
     pay_time::Union{ModelTime, Nothing} = nothing,
     discount_curve_key::Union{String,Nothing} = nothing,
-    ad_module::Module = ForwardDiff,
+    ad_module::Union{Module, DifferentiationInterface.AbstractADType} = ForwardDiff,
     )
     #
     if has_amc_payoff(payoffs) && (ad_module == Zygote)
@@ -131,7 +131,7 @@ end
         context::Context,
         pay_time::Union{ModelTime, Nothing} = nothing,
         discount_curve_key::Union{String,Nothing} = nothing,
-        ad_module::Module = ForwardDiff,
+        ad_module::Union{Module, DifferentiationInterface.AbstractADType} = ForwardDiff,
         )
 
 Calculate model price and model sensitivities. Sensitivities are
@@ -162,7 +162,7 @@ function model_price_and_vegas(
     context::Context,
     pay_time::Union{ModelTime, Nothing} = nothing,
     discount_curve_key::Union{String,Nothing} = nothing,
-    ad_module::Module = ForwardDiff,
+    ad_module::Union{Module, DifferentiationInterface.AbstractADType} = ForwardDiff,
     )
     #
     if has_amc_payoff(payoffs) && (ad_module == Zygote)

--- a/src/analytics/ValuationsViaZygote.jl
+++ b/src/analytics/ValuationsViaZygote.jl
@@ -39,7 +39,7 @@ function model_price_and_deltas_zygote(
         return mean( X )
     end
     # res = obj_function(path_obj.ts_dict)
-    (v, g) = _function_value_and_gradient(obj_function, path_obj.ts_dict, Zygote)
+    (v, g) = _function_value_and_gradient(obj_function, path_obj.ts_dict)
     return (v, g)
 end
 
@@ -118,6 +118,6 @@ function model_price_and_vegas_zygote(
         return price
     end
     # res = obj_function(param_dict)
-    (v, g) = _function_value_and_gradient(obj_function, param_dict, Zygote)
+    (v, g) = _function_value_and_gradient(obj_function, param_dict)
     return (v, g)
 end

--- a/src/chainrules/control.jl
+++ b/src/chainrules/control.jl
@@ -1,0 +1,11 @@
+
+function non_differentiable_warn(message)
+    @warn message
+end
+
+function non_differentiable_warn(message, variable)
+    @warn message variable
+end
+
+ChainRulesCore.@non_differentiable non_differentiable_warn(message)
+ChainRulesCore.@non_differentiable non_differentiable_warn(message, variable)

--- a/src/payoffs/UnaryNodes.jl
+++ b/src/payoffs/UnaryNodes.jl
@@ -25,7 +25,7 @@ Create a Pay object and check for consistency.
 function Pay(x::Payoff, pay_time::ModelTime)
     obs_time_x = obs_time(x)
     if pay_time < obs_time_x
-        @warn "Pay time is before observation time." pay_time obs_time_x
+        non_differentiable_warn("Pay time is before observation time.", (pay_time, obs_time_x))
     end
     return Pay(x, pay_time, true)
 end

--- a/src/serialisation/RebuildTermstructures.jl
+++ b/src/serialisation/RebuildTermstructures.jl
@@ -115,7 +115,7 @@ function termstructure_dictionary!(
             continue
         end
         if isa(ts_dict[ts_alias], ZeroCurve)
-            @warn "ZeroCurve rebuild does not work with Zygote. Consider using LinearZeroCurve."
+            non_differentiable_warn("ZeroCurve rebuild does not work with Zygote. Consider using LinearZeroCurve.")
             ts_dict[ts_alias] = zero_curve(ts_dict[ts_alias].alias, ts_dict[ts_alias].times, values)
             continue
         end

--- a/src/termstructures/credit/CreditDefaultTermstructures.jl
+++ b/src/termstructures/credit/CreditDefaultTermstructures.jl
@@ -77,10 +77,10 @@ function survival_curve(
     @assert length(times) > 0
     @assert length(times) == length(survival_probs)
     if times[begin] != 0.0
-        @warn "First time should typically be 0.0." times[begin]
+        non_differentiable_warn("First time should typically be 0.0.", times[begin])
     end
     if survival_probs[begin] != 1.0
-        @warn "First survival probability should typically be 1.0." survival_probs[begin]
+        non_differentiable_warn("First survival probability should typically be 1.0.", survival_probs[begin])
     end
     values = log.(survival_probs)
     return LogSurvivalCurve(alias, times, values, interp_method(times, values))

--- a/src/utils/Gradients.jl
+++ b/src/utils/Gradients.jl
@@ -29,14 +29,14 @@ function _function_value_and_gradient(
         return (v, g)
     end
     if m == Zygote
-        (v, g) = withgradient(f, x)
+        (v, g) = Zygote.withgradient(f, x)
         @assert length(g) == 1
         return (v, g[1])
     end
     if m == FiniteDifferences
         v = f(x)
-        m = central_fdm(3, 1)
-        g = grad(m, f, x)
+        m = FiniteDifferences.central_fdm(3, 1)
+        g = FiniteDifferences.grad(m, f, x)
         return (v, g[1])
     end
     error("Unknown module " * string(m) * ".")
@@ -56,7 +56,26 @@ function _function_value_and_gradient(
     x::Dict,
     )
     # only Zygote supports Dict
-    (v, g) = withgradient(f, x)
+    (v, g) = Zygote.withgradient(f, x)
     @assert length(g) == 1
     return (v, g[1])
+end
+
+
+"""
+    _function_value_and_gradient(
+        f::Function,
+        x::AbstractVector,
+        adType::DifferentiationInterface.AbstractADType,
+        )
+
+Calculate the function value and gradient of a function using DifferentiationInterface.
+"""
+function _function_value_and_gradient(
+    f::Function,
+    x::AbstractVector,
+    adType::DifferentiationInterface.AbstractADType,
+    )
+    #
+    return value_and_gradient(f, adType, x)
 end

--- a/src/utils/Gradients.jl
+++ b/src/utils/Gradients.jl
@@ -11,7 +11,7 @@ tuning AD routines.
 """
     _function_value_and_gradient(
         f::Function,
-        x::Any,
+        x::AbstractVector,
         m::Module = ForwardDiff,
         )
 
@@ -19,7 +19,7 @@ Calculate the function value and gradient of a function.
 """
 function _function_value_and_gradient(
     f::Function,
-    x::Any,
+    x::AbstractVector,
     m::Module = ForwardDiff,
     )
     #
@@ -40,4 +40,23 @@ function _function_value_and_gradient(
         return (v, g[1])
     end
     error("Unknown module " * string(m) * ".")
+end
+
+
+"""
+    _function_value_and_gradient(
+        f::Function,
+        x::Dict,
+        )
+
+Calculate the function value and gradient of a function using Zygote.
+"""
+function _function_value_and_gradient(
+    f::Function,
+    x::Dict,
+    )
+    # only Zygote supports Dict
+    (v, g) = withgradient(f, x)
+    @assert length(g) == 1
+    return (v, g[1])
 end

--- a/test/unittests/termstructures/credit/credit.jl
+++ b/test/unittests/termstructures/credit/credit.jl
@@ -30,4 +30,15 @@ using Test
         @test isapprox(cv(3.0), 0.5 * exp(-0.23104906018664842), atol=1.0e-14)
     end
 
+   @testset "Test warnings in LogSurvivalCurve" begin
+        times = [1.0, 2.0, 5.0]
+        survival_probs = [1.0, 0.5, 0.25]
+        @test_warn "First time should typically be 0.0." DiffFusion.survival_curve("Std", times, survival_probs)
+        #
+        times = [0.0, 2.0, 5.0]
+        survival_probs = [0.9, 0.5, 0.25]
+        DiffFusion.survival_curve("Std", times, survival_probs)
+        @test_warn "First survival probability should typically be 1.0." DiffFusion.survival_curve("Std", times, survival_probs)
+   end
+
 end


### PR DESCRIPTION
This PR re-enables Zygote with Julia 1.12. Moreover, we add DifferentiationInterface as a mean to calculate sensitivities.