### PR TITLE
Allow model state variables that do not depend on Brownian motion

### DIFF
--- a/src/models/Model.jl
+++ b/src/models/Model.jl
@@ -496,9 +496,10 @@ function covariance(
         Gamma = ch(factor_alias(m))
     end
     d = length(state_alias(m))
-    f(u) = vec(Sigma_T(m,s,t,X)(u) * Gamma * Sigma_T(m,s,t,X)(u)')
+    sigma_T = Sigma_T(m,s,t,X)
+    f(u) = vec(sigma_T(u) * Gamma * sigma_T(u)')
     cov_vec = _vector_integral(f, s, t, parameter_grid(m))
-    cov = reshape(cov_vec, (d,d))
+    cov = reshape(cov_vec, (d, d))
     return cov
 end
 

--- a/src/models/asset/AssetVolatility.jl
+++ b/src/models/asset/AssetVolatility.jl
@@ -33,12 +33,12 @@ function asset_variance(
     end
     if !isnothing(dom_model)
         models_ = vcat(models_, dom_model)
-        n = length(state_alias(dom_model))
+        n = length(state_alias_Sigma(dom_model))
         e = vcat(e, zeros(n-1), ones(1))
     end
     if !isnothing(for_model)
         models_ = vcat(models_, for_model)
-        n = length(state_alias(for_model))
+        n = length(state_alias_Sigma(for_model))
         e = vcat(e, zeros(n-1), -1.0*ones(1))
     end
     model = simple_model("", models_)

--- a/src/models/asset/CevAssetModel.jl
+++ b/src/models/asset/CevAssetModel.jl
@@ -69,7 +69,7 @@ end
 
 Return whether Theta requires a state vector input X.
 """
-state_dependent_Theta(m::CevAssetModel) = true
+state_dependent_Theta(m::CevAssetModel) = true  # COV_EXCL_LINE
 
 """
     state_alias_H(m::CevAssetModel)
@@ -83,7 +83,7 @@ state_alias_H(m::CevAssetModel) = state_alias(m)
 
 Return whether H requires a state vector input X.
 """
-state_dependent_H(m::CevAssetModel) = false
+state_dependent_H(m::CevAssetModel) = false  # COV_EXCL_LINE
 
 """
     state_alias_Sigma(m::CevAssetModel)
@@ -104,7 +104,7 @@ factor_alias_Sigma(m::CevAssetModel) = factor_alias(m)
 
 Return whether Sigma requires a state vector input X.
 """
-state_dependent_Sigma(m::CevAssetModel) = true
+state_dependent_Sigma(m::CevAssetModel) = true  # COV_EXCL_LINE
 
 
 """

--- a/src/models/asset/CevAssetModel.jl
+++ b/src/models/asset/CevAssetModel.jl
@@ -86,6 +86,13 @@ Return whether H requires a state vector input X.
 state_dependent_H(m::CevAssetModel) = false
 
 """
+    state_alias_Sigma(m::CevAssetModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::CevAssetModel) = state_alias(m::CevAssetModel)
+
+"""
     factor_alias_Sigma(m::CevAssetModel)
 
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.

--- a/src/models/asset/LognormalAssetModel.jl
+++ b/src/models/asset/LognormalAssetModel.jl
@@ -76,7 +76,7 @@ state_alias_H(m::LognormalAssetModel) = state_alias(m)
 
 Return whether H requires a state vector input X.
 """
-state_dependent_H(m::LognormalAssetModel) = false
+state_dependent_H(m::LognormalAssetModel) = false  # COV_EXCL_LINE
 
 """
     state_alias_Sigma(m::LognormalAssetModel)
@@ -97,7 +97,7 @@ factor_alias_Sigma(m::LognormalAssetModel) = factor_alias(m)
 
 Return whether Sigma requires a state vector input X.
 """
-state_dependent_Sigma(m::LognormalAssetModel) = false
+state_dependent_Sigma(m::LognormalAssetModel) = false  # COV_EXCL_LINE
 
 """
     asset_volatility(

--- a/src/models/asset/LognormalAssetModel.jl
+++ b/src/models/asset/LognormalAssetModel.jl
@@ -79,6 +79,13 @@ Return whether H requires a state vector input X.
 state_dependent_H(m::LognormalAssetModel) = false
 
 """
+    state_alias_Sigma(m::LognormalAssetModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::LognormalAssetModel) = state_alias(m::LognormalAssetModel)
+
+"""
     factor_alias_Sigma(m::LognormalAssetModel)
 
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.

--- a/src/models/credit/CoxIngersollRossModel.jl
+++ b/src/models/credit/CoxIngersollRossModel.jl
@@ -164,26 +164,43 @@ end
 # Model interface
 
 """
+    state_dependent_Theta(m::CoxIngersollRossModel)
+
 Return whether Theta requires a state vector input X.
 """
 state_dependent_Theta(m::CoxIngersollRossModel) = true
 
 """
+    state_alias_H(m::CoxIngersollRossModel)
+
 Return a list of state alias strings required for (H * X) calculation.
 """
 state_alias_H(m::CoxIngersollRossModel) = state_alias(m)
 
 """
+    state_dependent_H(m::CoxIngersollRossModel)
+
 Return whether H requires a state vector input X.
 """
 state_dependent_H(m::CoxIngersollRossModel) = false
 
 """
+    state_alias_Sigma(m::CoxIngersollRossModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::CoxIngersollRossModel) = state_alias(m::CoxIngersollRossModel)
+
+"""
+    factor_alias_Sigma(m::CoxIngersollRossModel)
+
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.
 """
 factor_alias_Sigma(m::CoxIngersollRossModel) = factor_alias(m)
 
 """
+    state_dependent_Sigma(m::CoxIngersollRossModel)
+
 Return whether Sigma requires a state vector input X.
 """
 state_dependent_Sigma(m::CoxIngersollRossModel) = true

--- a/src/models/credit/CoxIngersollRossModel.jl
+++ b/src/models/credit/CoxIngersollRossModel.jl
@@ -168,7 +168,7 @@ end
 
 Return whether Theta requires a state vector input X.
 """
-state_dependent_Theta(m::CoxIngersollRossModel) = true
+state_dependent_Theta(m::CoxIngersollRossModel) = true  # COV_EXCL_LINE
 
 """
     state_alias_H(m::CoxIngersollRossModel)
@@ -182,7 +182,7 @@ state_alias_H(m::CoxIngersollRossModel) = state_alias(m)
 
 Return whether H requires a state vector input X.
 """
-state_dependent_H(m::CoxIngersollRossModel) = false
+state_dependent_H(m::CoxIngersollRossModel) = false  # COV_EXCL_LINE
 
 """
     state_alias_Sigma(m::CoxIngersollRossModel)
@@ -203,7 +203,7 @@ factor_alias_Sigma(m::CoxIngersollRossModel) = factor_alias(m)
 
 Return whether Sigma requires a state vector input X.
 """
-state_dependent_Sigma(m::CoxIngersollRossModel) = true
+state_dependent_Sigma(m::CoxIngersollRossModel) = true  # COV_EXCL_LINE
 
 
 """

--- a/src/models/futures/MarkovFutureModels.jl
+++ b/src/models/futures/MarkovFutureModels.jl
@@ -116,6 +116,13 @@ Return whether H requires a state vector input X.
 state_dependent_H(m::MarkovFutureModel) = state_dependent_H(m.hjm_model)
 
 """
+    state_alias_Sigma(m::MarkovFutureModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::MarkovFutureModel) = state_alias(m::MarkovFutureModel)
+
+"""
     factor_alias_Sigma(m::MarkovFutureModel)
 
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.

--- a/src/models/hybrid/CompositeModel.jl
+++ b/src/models/hybrid/CompositeModel.jl
@@ -328,6 +328,15 @@ function state_dependent_H(m::CompositeModel)
 end
 
 """
+    state_alias_Sigma(m::CompositeModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+
+This is a default behaviour. It is supposed to be overwritten for derived Model types.
+"""
+state_alias_Sigma(m::CompositeModel) = state_alias(m::CompositeModel)
+
+"""
     factor_alias_Sigma(m::CompositeModel)
 
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.

--- a/src/models/hybrid/DiagonalModel.jl
+++ b/src/models/hybrid/DiagonalModel.jl
@@ -118,14 +118,15 @@ function Sigma_T(
     @assert size(X.X)[2] == 1  # require a single state
     @assert isa(X.params, NamedTuple)
     for cm in m.models
-        @assert factor_alias(cm) == factor_alias_Sigma(cm)  # deal with general case later...
+        @assert state_alias(cm) == state_alias_Sigma(cm)  # deal with general case later...
+        @assert factor_alias(cm) == factor_alias_Sigma(cm)
     end
     Sigma_T_s = (
         (!state_dependent_Sigma(cm)) ? (Sigma_T(cm, s, t)) : (Sigma_T(cm, s, t, ModelState(X.X, X.idx, P)))
         for (cm, P) in zip(m.models, X.params.P)
         )
-    N = length(state_alias(m))
-    M = length(factor_alias(m))
+    M = length(state_alias_Sigma(m))
+    N = length(factor_alias_Sigma(m))
     f(u) = begin
         I = Int[]
         J = Int[]
@@ -137,11 +138,9 @@ function Sigma_T(
             I = vcat(I, I_)
             J = vcat(J, J_)
             V = vcat(V, V_)
-            idx_i += length(state_alias(cm))
+            idx_i += length(state_alias_Sigma(cm))
             idx_j += length(factor_alias_Sigma(cm))
         end
-        M = length(state_alias(m))
-        N = length(factor_alias_Sigma(m))
         sigma_T = sparse(I, J, V, M, N)
         return sigma_T
     end

--- a/src/models/hybrid/SimpleModel.jl
+++ b/src/models/hybrid/SimpleModel.jl
@@ -117,11 +117,12 @@ function Sigma_T(
     )
     @assert isnothing(X) == !state_dependent_Sigma(m)
     for cm in m.models
-        @assert factor_alias(cm) == factor_alias_Sigma(cm)  # deal with general case later...
+        @assert state_alias(cm) == state_alias_Sigma(cm)  # deal with general case later...
+        @assert factor_alias(cm) == factor_alias_Sigma(cm)
     end
     Sigma_T_s = ( Sigma_T(cm,s,t,X) for cm in m.models )
-    N = length(state_alias(m))
-    M = length(factor_alias(m))
+    M = length(state_alias_Sigma(m))
+    N = length(factor_alias_Sigma(m))
     f(u) = begin
         I = Int[]
         J = Int[]
@@ -133,11 +134,9 @@ function Sigma_T(
             I = vcat(I, I_)
             J = vcat(J, J_)
             V = vcat(V, V_)
-            idx_i += length(state_alias(cm))
+            idx_i += length(state_alias_Sigma(cm))
             idx_j += length(factor_alias_Sigma(cm))
         end
-        M = length(state_alias(m))
-        N = length(factor_alias_Sigma(m))
         sigma_T = sparse(I, J, V, M, N)
         return sigma_T
     end

--- a/src/models/processes/OrnsteinUhlenbeckModel.jl
+++ b/src/models/processes/OrnsteinUhlenbeckModel.jl
@@ -38,32 +38,51 @@ end
 # Model interface
 
 """
+    parameter_grid(m::OrnsteinUhlenbeckModel)
+
 Return a list of times representing the (joint) grid points of piece-wise
 constant model parameters.
 """
 parameter_grid(m::OrnsteinUhlenbeckModel) = m.sigma_x.times
 
 """
+    state_dependent_Theta(m::OrnsteinUhlenbeckModel)
+
 Return whether Theta requires a state vector input X.
 """
 state_dependent_Theta(m::OrnsteinUhlenbeckModel) = false  # COV_EXCL_LINE
 
 """
+    state_alias_H(m::OrnsteinUhlenbeckModel)
+
 Return a list of state alias strings required for (H * X) calculation.
 """
 state_alias_H(m::OrnsteinUhlenbeckModel) = state_alias(m)
 
 """
+    state_dependent_H(m::OrnsteinUhlenbeckModel)
+
 Return whether H requires a state vector input X.
 """
 state_dependent_H(m::OrnsteinUhlenbeckModel) = false  # COV_EXCL_LINE
 
 """
+    state_alias_Sigma(m::OrnsteinUhlenbeckModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::OrnsteinUhlenbeckModel) = state_alias(m::OrnsteinUhlenbeckModel)
+
+"""
+    factor_alias_Sigma(m::OrnsteinUhlenbeckModel)
+
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.
 """
 factor_alias_Sigma(m::OrnsteinUhlenbeckModel) = factor_alias(m)
 
 """
+    state_dependent_Sigma(m::OrnsteinUhlenbeckModel)
+
 Return whether Sigma requires a state vector input X.
 """
 state_dependent_Sigma(m::OrnsteinUhlenbeckModel) = false  # COV_EXCL_LINE

--- a/src/models/rates/GaussianHjmModel.jl
+++ b/src/models/rates/GaussianHjmModel.jl
@@ -162,7 +162,7 @@ state_alias_H(m::GaussianHjmModel) = state_alias(m)
 
 Return whether H requires a state vector input X.
 """
-state_dependent_H(m::GaussianHjmModel) = false
+state_dependent_H(m::GaussianHjmModel) = false  # COV_EXCL_LINE
 
 """
     state_alias_Sigma(m::GaussianHjmModel)
@@ -183,7 +183,7 @@ factor_alias_Sigma(m::GaussianHjmModel) = factor_alias(m)
 
 Return whether Sigma requires a state vector input X.
 """
-state_dependent_Sigma(m::GaussianHjmModel) = false
+state_dependent_Sigma(m::GaussianHjmModel) = false  # COV_EXCL_LINE
 
 
 """

--- a/src/models/rates/GaussianHjmModel.jl
+++ b/src/models/rates/GaussianHjmModel.jl
@@ -165,6 +165,13 @@ Return whether H requires a state vector input X.
 state_dependent_H(m::GaussianHjmModel) = false
 
 """
+    state_alias_Sigma(m::GaussianHjmModel)
+
+Return a list of state alias strings required for (Sigma(u)' Gamma Sigma(u)) calculation.
+"""
+state_alias_Sigma(m::GaussianHjmModel) = state_alias(m::GaussianHjmModel)
+
+"""
     factor_alias_Sigma(m::GaussianHjmModel)
 
 Return a list of factor alias strings required for (Sigma(u)^T Gamma Sigma(u)) calculation.

--- a/src/simulations/Simulation.jl
+++ b/src/simulations/Simulation.jl
@@ -48,8 +48,9 @@ function simple_simulation(
     brownian_increments::Function = pseudo_brownian_increments,
     store_brownian_increments::Bool = false,
     )
+    @assert state_alias(model) == state_alias_Sigma(model)  # deal with general case later...
     dZ = brownian_increments(
-        length(state_alias(model)),
+        length(state_alias_Sigma(model)),
         n_paths,
         length(times) - 1,
     )
@@ -63,7 +64,7 @@ function simple_simulation(
         X_t = Theta(model,times[k-1],times[k]) .+ H_T(model,times[k-1],times[k])' * X[:,:,k-1]
         (vol, corr) = volatility_and_correlation(model,ch,times[k-1],times[k])
         L = cholesky(corr).L
-        # apply diffusion
+        # apply diffusion, require state_alias == state_alias_Sigma
         X_t += (sqrt(times[k] - times[k-1]) * (L .* vol)) * dZ[:,:,k-1]
         X = cat(X, X_t, dims=3)
     end
@@ -97,8 +98,9 @@ function diagonal_simulation(
     brownian_increments::Function = pseudo_brownian_increments,
     store_brownian_increments::Bool = false,
     )
+    @assert state_alias(model) == state_alias_Sigma(model)  # deal with general case later...
     dZ = brownian_increments(
-        length(state_alias(model)),
+        length(state_alias_Sigma(model)),
         n_paths,
         length(times) - 1,
     )
@@ -121,7 +123,7 @@ function diagonal_simulation(
         SX = model_state(X[:,:,k-1], idx, params)
         Vol = diagonal_volatility(model, times[k-1], times[k], SX)
         L = cholesky(corr).L
-        # apply diffusion
+        # apply diffusion, require state_alias == state_alias_Sigma
         X_t += sqrt(times[k] - times[k-1]) * L * dZ[:,:,k-1] .* Vol
         X = cat(X, X_t, dims=3)
     end

--- a/test/unittests/models/models.jl
+++ b/test/unittests/models/models.jl
@@ -43,6 +43,7 @@ using Test
         #
         @test_throws ErrorException DiffFusion.Sigma_T(m, 1.0, 2.0)
         @test_throws ErrorException DiffFusion.Sigma_T(m, 1.0, 2.0, SX)
+        @test_throws ErrorException DiffFusion.state_alias_Sigma(m)
         @test_throws ErrorException DiffFusion.factor_alias_Sigma(m)
         @test_throws ErrorException DiffFusion.state_dependent_Sigma(m)
         #

--- a/test/unittests/models/rates/swap_rate_calibration.jl
+++ b/test/unittests/models/rates/swap_rate_calibration.jl
@@ -335,10 +335,10 @@ using Test
         # display(res)
         @test all(res.fit .> -5.5e-4)
         @test all(res.fit .<  4.2e-4)
-        display(res.model.chi)
-        display(res.model.sigma_T.sigma_f.times)
-        display(res.model.sigma_T.sigma_f.values)
-        display(res.fit * 1e+4)
+        # display(res.model.chi)
+        # display(res.model.sigma_T.sigma_f.times)
+        # display(res.model.sigma_T.sigma_f.values)
+        # display(res.fit * 1e+4)
     end
 
 end


### PR DESCRIPTION
This PR generalises the calculation of the volatility $\Sigma^T(u)$. We allow that volatility is calculated for a sub-set of state aliases that do indeed depend on Brownian motion. These state variables are identified by `state_alias_Sigma(m::Model)`.

The generalisation aims at allowing for models that have state variables which are *not* driven by Brownian motion. Such state variables could be modelled by zero volatility. However, such an approach would inflate the covariance matrix. Moreover, covariance matrix would not be positive definite anymore. This complicates (Cholesky) decomposition.