### PR TITLE
Improve type stability

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ using DiffFusion
 """
 A type alias for variables representing time.
 """
-ModelTime = Number
+ModelTime = Float64
 
 """
 A type alias for variables representing modelled quantities.

--- a/docs/src/termstructures/termstructures.md
+++ b/docs/src/termstructures/termstructures.md
@@ -11,7 +11,3 @@ DiffFusion.Termstructure
 ```@docs
 DiffFusion.alias(ts::DiffFusion.Termstructure)
 ```
-
-```@docs
-DiffFusion.TermstructureResultSize
-```

--- a/docs/src/termstructures/volatilities.md
+++ b/docs/src/termstructures/volatilities.md
@@ -29,7 +29,6 @@ Call operator for `VolatilityTermstructure` is defined as
 DiffFusion.volatility(
     ts::DiffFusion.VolatilityTermstructure,
     t::ModelTime,
-    result_size::DiffFusion.TermstructureResultSize = DiffFusion.TermstructureVector,
     )
 ```
 
@@ -45,7 +44,6 @@ DiffFusion.volatility(
 DiffFusion.volatility(
     ts::DiffFusion.BackwardFlatVolatility,
     t::ModelTime,
-    result_size::DiffFusion.TermstructureResultSize = DiffFusion.TermstructureVector,
     )
 ```
 

--- a/src/DiffFusion.jl
+++ b/src/DiffFusion.jl
@@ -30,7 +30,7 @@ import Base.string
 """
 A type alias for variables representing time.
 """
-ModelTime = Number
+ModelTime = Float64
 
 """
 A type alias for variables representing modelled quantities.

--- a/src/examples/Examples.jl
+++ b/src/examples/Examples.jl
@@ -40,7 +40,7 @@ Return the first object of a given type from an example dictionary.
 """
 function get_object(example::OrderedDict{String,Any}, obj_type)
     for value in values(example)
-        if typeof(value) == obj_type
+        if isa(value, obj_type)
             return value
         end
     end

--- a/src/models/asset/AssetModel.jl
+++ b/src/models/asset/AssetModel.jl
@@ -10,6 +10,14 @@ We implement several additional functions to handle quanto adjustments.
 abstract type AssetModel <: ComponentModel end
 
 """
+    abstract type AssetVolatility end
+
+A functor calculating the state-independent volatility function sigma(u) for the interval (s,t).
+"""
+abstract type AssetVolatility end
+
+
+"""
     asset_volatility(
         m::AssetModel,
         s::ModelTime,
@@ -17,7 +25,7 @@ abstract type AssetModel <: ComponentModel end
         X::Union{ModelState, Nothing} = nothing,
         )
 
-Return a state-independent volatility function sigma(u) for the interval (s,t).
+Return an AssetVolatility functor.
 """
 function asset_volatility(
     m::AssetModel,
@@ -37,7 +45,24 @@ function correlation_holder(m::AssetModel)
     return m.correlation_holder
 end
 
+"""
+    abstract type QuantoDrift end
 
+A functor calculating the state-independent quanto drift adjustment.
+"""
+abstract type QuantoDrift end
+
+"""
+A trivial quanto adjustment.
+"""
+struct ZeroQuantoDrift <: QuantoDrift
+    d::Int
+end
+
+"""
+Evaluate `ZeroQuantoDrift` at `t`.
+"""
+(qd::ZeroQuantoDrift)(t::ModelTime) = zeros(qd.d)
 
 """
     quanto_drift(
@@ -57,10 +82,22 @@ function quanto_drift(
     t::ModelTime,
     X::Union{ModelState, Nothing} = nothing,
     )
-    alpha(u) = zeros(length(dom_factor_alias))
-    return alpha
+    #
+    return ZeroQuantoDrift(length(dom_factor_alias))
 end
 
+"""
+Quanto adjustment functor for `AssetModel`.
+"""
+struct AssetModelQuantoDrift{T1<:ModelValue, T2<:AssetVolatility} <: QuantoDrift
+    Gamma::Vector{T1}
+    vol::T2
+end
+
+"""
+Evaluate `AssetModelQuantoDrift` at `t`.
+"""
+(qd::AssetModelQuantoDrift)(t::ModelTime) = qd.Gamma .* qd.vol(t)
 
 """
     quanto_drift(
@@ -82,10 +119,9 @@ function quanto_drift(
     X::Union{ModelState, Nothing} = nothing,
     )
     ch = correlation_holder(quanto_model)
-    quanto_factor_alias = factor_alias(quanto_model)[1]  # This is an assumption
+    quanto_factor_alias = factor_alias(quanto_model)[begin]  # This is an assumption
     # ch() returns an (N,1) matrix, but we want to return an (N,) vector
     Gamma = vec(ch(dom_factor_alias, quanto_factor_alias))
-    vol = asset_volatility(quanto_model,s,t,X)
-    alpha(u) = Gamma * vol(u)
-    return alpha
+    vol = asset_volatility(quanto_model, s, t, X)
+    return AssetModelQuantoDrift(Gamma, vol)
 end

--- a/src/models/credit/CoxIngersollRossModel.jl
+++ b/src/models/credit/CoxIngersollRossModel.jl
@@ -3,11 +3,11 @@
 """
 A Cox-Ingersoll-Ross model with constant parameters.
 """
-struct CoxIngersollRossModel <: ComponentModel
+struct CoxIngersollRossModel{T<:ModelValue} <: ComponentModel
     alias::String
-    params::ParameterTermstructure  # (z0, chi, theta, sigma)
-    state_alias::AbstractVector
-    factor_alias::AbstractVector
+    params::BackwardFlatParameter{T}  # (z0, chi, theta, sigma)
+    state_alias::Vector{String}
+    factor_alias::Vector{String}
 end
 
 """
@@ -282,7 +282,7 @@ function Sigma_T(
     z_s = cir_z0(m) * exp.(x_s)
     (a, b2) = cir_lognormal_approximation(m,z_s,X.params)
     Σ_x = sqrt.(b2 ./ (t-s))
-    f(u) = reshape(Σ_x, (1,1))
+    f = (u) -> reshape(Σ_x, (1,1))
     return f
 end
 

--- a/src/models/hybrid/DiagonalModel.jl
+++ b/src/models/hybrid/DiagonalModel.jl
@@ -4,9 +4,9 @@
     struct DiagonalModel <: CompositeModel
         alias::String
         models::Tuple
-        state_alias::AbstractVector
-        factor_alias::AbstractVector
-        state_alias_Sigma::AbstractVector
+        state_alias::Vector{String}
+        factor_alias::Vector{String}
+        state_alias_Sigma::Vector{String}
         model_dict::Dict{String,Int}
     end
 
@@ -19,12 +19,12 @@ For state-independent models we avoid repeated Theta and Sigma calculation.
 
 The model is used as a hybrid model for simulation and payoff evaluation.
 """
-struct DiagonalModel <: CompositeModel
+struct DiagonalModel{ModelsType<:Tuple} <: CompositeModel
     alias::String
-    models::Tuple
-    state_alias::AbstractVector
-    factor_alias::AbstractVector
-    state_alias_Sigma::AbstractVector
+    models::ModelsType
+    state_alias::Vector{String}
+    factor_alias::Vector{String}
+    state_alias_Sigma::Vector{String}
     model_dict::Dict{String,Int}
 end
 
@@ -37,7 +37,7 @@ function diagonal_model(m_alias::String, models::AbstractVector)
     s_alias = vcat((state_alias(cm) for cm in models)...)
     f_alias = vcat((factor_alias(cm) for cm in models)...)
     s_alias_Sigma = vcat((state_alias_Sigma(cm) for cm in models)...)
-    model_dict = Dict()
+    model_dict = Dict{String,Int}()
     for (k,cm) in enumerate(models)
         model_dict[alias(cm)] = k
     end
@@ -149,7 +149,7 @@ function Sigma_T(
     )
     M = length(state_alias_Sigma(m))
     N = length(factor_alias_Sigma(m))
-    f(u) = begin
+    f = (u) -> begin
         I = Int[]
         J = Int[]
         V = zeros(0)

--- a/src/models/hybrid/SimpleModel.jl
+++ b/src/models/hybrid/SimpleModel.jl
@@ -3,8 +3,8 @@
     struct SimpleModel <: Model
         alias::String
         models::Tuple
-        state_alias::AbstractVector
-        factor_alias::AbstractVector
+        state_alias::Vector{String}
+        factor_alias::Vector{String}
         model_dict::Dict{String,Int}
     end
 
@@ -13,11 +13,11 @@ component models.
 
 It is supposed to be used with a `simple_simulation()` method.
 """
-struct SimpleModel <: CompositeModel
+struct SimpleModel{ModelsType<:Tuple} <: CompositeModel
     alias::String
-    models::Tuple
-    state_alias::AbstractVector
-    factor_alias::AbstractVector
+    models::ModelsType
+    state_alias::Vector{String}
+    factor_alias::Vector{String}
     model_dict::Dict{String,Int}
 end
 
@@ -30,7 +30,7 @@ Create a SimpleModel.
 function simple_model(m_alias::String, models::AbstractVector)
     s_alias = vcat((state_alias(cm) for cm in models)...)
     f_alias = vcat((factor_alias(cm) for cm in models)...)
-    model_dict = Dict()
+    model_dict = Dict{String,Int}()
     for (k,cm) in enumerate(models)
         model_dict[alias(cm)] = k
     end
@@ -123,7 +123,7 @@ function Sigma_T(
     Sigma_T_s = ( Sigma_T(cm,s,t,X) for cm in m.models )
     M = length(state_alias_Sigma(m))
     N = length(factor_alias_Sigma(m))
-    f(u) = begin
+    f = (u) -> begin
         I = Int[]
         J = Int[]
         V = zeros(0)

--- a/src/models/processes/OrnsteinUhlenbeckModel.jl
+++ b/src/models/processes/OrnsteinUhlenbeckModel.jl
@@ -3,12 +3,12 @@
 An Ornstein-Uhlenbeck model with constant mean reversion
 and piece-wise flat volatility.
 """
-struct OrnsteinUhlenbeckModel <: ComponentModel
+struct OrnsteinUhlenbeckModel{T<:ModelValue} <: ComponentModel
     alias::String
-    chi::ParameterTermstructure
-    sigma_x::BackwardFlatVolatility
-    state_alias::AbstractVector
-    factor_alias::AbstractVector
+    chi::BackwardFlatParameter{T}
+    sigma_x::BackwardFlatVolatility{T}
+    state_alias::Vector{String}
+    factor_alias::Vector{String}
 end
 
 
@@ -151,7 +151,7 @@ function Sigma_T(
     X::Union{ModelState, Nothing} = nothing,
     )
     @assert isnothing(X) == !state_dependent_Sigma(m)
-    f(u) = reshape(H_hjm(m.chi(), u, t) .* m.sigma_x(u), 1, 1)
+    f = (u) -> reshape(H_hjm(m.chi(), u, t) .* m.sigma_x(u), 1, 1)
     return f
 end
 

--- a/src/paths/PathMethods.jl
+++ b/src/paths/PathMethods.jl
@@ -207,7 +207,7 @@ function asset(p::Path, t::ModelTime, key::String)
     entry = p.context.assets[context_key]
     #
     spot_alias = entry.asset_spot_alias
-    spot = p.ts_dict[spot_alias](t, TermstructureScalar)
+    spot = scalar_value(p.ts_dict[spot_alias], t)
     #
     ts_alias_1 = entry.foreign_termstructure_dict[ts_key_1]
     ts_alias_2 = entry.domestic_termstructure_dict[ts_key_2]
@@ -281,7 +281,7 @@ function forward_asset(p::Path, t::ModelTime, T::ModelTime, key::String)
     entry = p.context.assets[context_key]
     #
     spot_alias = entry.asset_spot_alias
-    spot = p.ts_dict[spot_alias](T, TermstructureScalar)  # capture any discrete jumps until T
+    spot = scalar_value(p.ts_dict[spot_alias], T)  # capture any discrete jumps until T
     #
     ts_alias_1 = entry.foreign_termstructure_dict[ts_key_1]
     ts_alias_2 = entry.domestic_termstructure_dict[ts_key_2]
@@ -352,7 +352,7 @@ end
 
 
 """
-    forward_asset_zero_bonds(p::Path, t::ModelTime, T::ModelTime, key::String)
+    forward_asset_and_zero_bonds(p::Path, t::ModelTime, T::ModelTime, key::String)
 
 Calculate asset (plus deterministic jumps) as well as domestic and foreign
 zero bond price associated with an `Asset` key.
@@ -369,7 +369,7 @@ function forward_asset_and_zero_bonds(p::Path, t::ModelTime, T::ModelTime, key::
     entry = p.context.assets[context_key]
     #
     spot_alias = entry.asset_spot_alias
-    spot = p.ts_dict[spot_alias](T, TermstructureScalar)  # capture any discrete jumps until T to be consistent with forward_asset
+    spot = scalar_value(p.ts_dict[spot_alias], T)  # capture any discrete jumps until T to be consistent with forward_asset
     #
     ts_alias_dom = entry.domestic_termstructure_dict[ts_key_dom]
     df_dom_t = discount(t, p.ts_dict, ts_alias_dom)
@@ -422,7 +422,7 @@ function fixing(p::Path, t::ModelTime, key::String)
     entry = p.context.fixings[context_key]
     #
     ts_alias = entry.termstructure_alias
-    fixing = p.ts_dict[ts_alias](t, TermstructureScalar)
+    fixing = scalar_value(p.ts_dict[ts_alias], t)
     return fixing .* ones(length(p))
 end
 
@@ -440,7 +440,7 @@ function forward_index(p::Path, t::ModelTime, T::ModelTime, key::String)
     entry = p.context.forward_indices[context_key]
     #
     forward_index_alias = entry.forward_index_alias
-    forward_index = p.ts_dict[forward_index_alias](T, TermstructureScalar)
+    forward_index = scalar_value(p.ts_dict[forward_index_alias], T)
     #
     if isnothing(entry.asset_model_alias) &&
         isnothing(entry.foreign_model_alias) &&
@@ -483,7 +483,7 @@ function future_index(p::Path, t::ModelTime, T::ModelTime, key::String)
     entry = p.context.future_indices[context_key]
     #
     future_index_alias = entry.future_index_alias
-    future_index = p.ts_dict[future_index_alias](T, TermstructureScalar)
+    future_index = scalar_value(p.ts_dict[future_index_alias], T)
     #
     if isnothing(entry.future_model_alias)
         # we can take a short-cut for fully deterministic models

--- a/src/serialisation/Models.jl
+++ b/src/serialisation/Models.jl
@@ -28,7 +28,7 @@ Serialise GaussianHjmModel.
 """
 function serialise(o::GaussianHjmModel)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "gaussian_hjm_model"
     d["alias"]       = serialise(o.alias)
     d["delta"]       = serialise(o.delta)
@@ -59,7 +59,7 @@ Serialise QuasiGaussianModel.
 function serialise(o::QuasiGaussianModel)
     g = o.gaussian_model
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "quasi_gaussian_model"
     d["alias"]       = serialise(g.alias)
     d["delta"]       = serialise(g.delta)
@@ -102,7 +102,7 @@ Serialise LognormalAssetModel.
 """
 function serialise(o::LognormalAssetModel)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "lognormal_asset_model"
     d["alias"]       = serialise(o.alias)
     d["sigma_x"]     = serialise(o.sigma_x)
@@ -123,7 +123,7 @@ Serialise CevAssetModel.
 """
 function serialise(o::CevAssetModel)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "cev_asset_model"
     d["alias"]       = serialise(o.alias)
     d["sigma_x"]     = serialise(o.sigma_x)
@@ -145,7 +145,7 @@ Serialise OrnsteinUhlenbeckModel.
 """
 function serialise(o::OrnsteinUhlenbeckModel)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "ornstein_uhlenbeck_model"
     d["alias"]       = serialise(o.alias)
     d["chi"]         = serialise(o.chi)
@@ -161,7 +161,7 @@ Serialise SimpleModel.
 """
 function serialise(o::SimpleModel)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "simple_model"
     d["alias"]       = serialise(o.alias)
     d["models"]      = serialise([ m for m in o.models ])
@@ -196,7 +196,7 @@ function serialise_as_list(o::SimpleModel)
     dict_list = [ serialise(obj_dict[key]) for key in keys(obj_dict) ]
     #
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "simple_model"
     d["alias"]       = serialise(o.alias)
     d["models"]      = [ serialise_key(m.alias) for m in o.models ]

--- a/src/serialisation/RebuildModels.jl
+++ b/src/serialisation/RebuildModels.jl
@@ -126,7 +126,7 @@ function build_model(
     @assert(haskey(param_dict, alias))
     m_dict = param_dict[alias]
     @assert(haskey(m_dict, "type"))
-    if m_dict["type"] == GaussianHjmModel
+    if m_dict["type"] <: GaussianHjmModel
         if isnothing(m_dict["correlation_holder"])
             ch = nothing
         else
@@ -147,7 +147,7 @@ function build_model(
             m_dict["scaling_type"],
         )
     end
-    if m_dict["type"] == LognormalAssetModel
+    if m_dict["type"] <: LognormalAssetModel
         ch = param_dict[m_dict["correlation_holder"]]  # LognormalAssetModel requires correlation_holder
         if isnothing(m_dict["quanto_model"])
             quanto_model = nothing
@@ -161,7 +161,7 @@ function build_model(
             quanto_model,
         )
     end
-    if m_dict["type"] == CevAssetModel
+    if m_dict["type"] <: CevAssetModel
         ch = param_dict[m_dict["correlation_holder"]]  # CevAssetModel requires correlation_holder
         if isnothing(m_dict["quanto_model"])
             quanto_model = nothing
@@ -176,7 +176,7 @@ function build_model(
             quanto_model,
         )
     end
-    if m_dict["type"] == SimpleModel
+    if m_dict["type"] <: SimpleModel
         simple_model_dict = Dict{String, Any}()
         for a in m_dict["models"]
             # here the order of models is relevant
@@ -285,18 +285,18 @@ function model_volatility_values(
     m_dict = param_dict[alias]
     #
     @assert(haskey(m_dict, "type"))
-    if m_dict["type"] == GaussianHjmModel
+    if m_dict["type"] <: GaussianHjmModel
         return _get_labels_and_values(alias, "sigma_f", m_dict)
     end
-    if m_dict["type"] == LognormalAssetModel
+    if m_dict["type"] <: LognormalAssetModel
         return _get_labels_and_values(alias, "sigma_x", m_dict)
     end
-    if m_dict["type"] == CevAssetModel
+    if m_dict["type"] <: CevAssetModel
         (l1, v1) = _get_labels_and_values(alias, "sigma_x", m_dict)
         (l2, v2) = _get_labels_and_values(alias, "skew_x", m_dict)
         return (vcat(l1, l2), vcat(v1, v2))
     end
-    if m_dict["type"] == SimpleModel
+    if m_dict["type"] <: SimpleModel
         vol_labels_values = [
             model_volatility_values(a, param_dict)
             for a in m_dict["models"]

--- a/src/serialisation/RebuildTermstructures.jl
+++ b/src/serialisation/RebuildTermstructures.jl
@@ -14,9 +14,10 @@ function.
 Extract labels and values from FlatForward.
 """
 function _get_labels_and_values(ts::FlatForward)
+    type_name = _type_name_long(ts)
     param_labels = [
         alias(ts) * _split_alias_identifyer *
-        string(typeof(ts)) * _split_alias_identifyer *
+        type_name * _split_alias_identifyer *
         "rate"
     ]
     param_values = [ ts.rate ]
@@ -30,9 +31,10 @@ end
 Extract labels and values from ZeroCurve.
 """
 function _get_labels_and_values(ts::ZeroCurve)
+    type_name = _type_name_long(ts)
     param_labels = [
         alias(ts) * _split_alias_identifyer *
-        string(typeof(ts)) * _split_alias_identifyer *
+        type_name * _split_alias_identifyer *
         (@sprintf("%.2f", t))
         for t in ts.times
     ]
@@ -46,9 +48,10 @@ end
 Extract labels and values from LinearZeroCurve.
 """
 function _get_labels_and_values(ts::LinearZeroCurve)
+    type_name = _type_name_long(ts)
     param_labels = [
         alias(ts) * _split_alias_identifyer *
-        string(typeof(ts)) * _split_alias_identifyer *
+        type_name * _split_alias_identifyer *
         (@sprintf("%.2f", t))
         for t in ts.times
     ]
@@ -62,10 +65,11 @@ end
 Extract labels and values from PiecewiseFlatParameter.
 """
 function _get_labels_and_values(ts::PiecewiseFlatParameter)
-    @assert(size(ts.values)[1] == 1)  # we need to deal with multi-factor parameters separately 
+    @assert(size(ts.values)[1] == 1)  # we need to deal with multi-factor parameters separately
+    type_name = _type_name_long(ts)
     param_labels = [
         alias(ts) * _split_alias_identifyer *
-        string(typeof(ts)) * _split_alias_identifyer *
+        type_name * _split_alias_identifyer *
         (@sprintf("%.2f", t))
         for t in ts.times
     ]
@@ -106,7 +110,7 @@ function termstructure_dictionary!(
         @assert ts_alias in keys(ts_dict)
         @assert length(keys(ts_dict_)) == 1
         ts_type_string = first(keys(ts_dict_))
-        @assert string(typeof(ts_dict[ts_alias])) == ts_type_string
+        @assert _type_name_long(ts_dict[ts_alias]) == ts_type_string
         #
         values = ts_dict_[ts_type_string]
         if isa(ts_dict[ts_alias], FlatForward)

--- a/src/serialisation/Termstructures.jl
+++ b/src/serialisation/Termstructures.jl
@@ -13,7 +13,7 @@ Serialise ZeroCurve.
 """
 function serialise(o::ZeroCurve)
     d = OrderedDict{String, Any}()
-    d["typename"]    = string(typeof(o))
+    d["typename"]    = _type_name_long(o)
     d["constructor"] = "zero_curve"
     d["alias"]       = serialise(o.alias)
     d["times"]       = serialise(o.times)
@@ -49,7 +49,7 @@ Serialise CorrelationHolder.
 """
 function serialise(o::CorrelationHolder)
     d = OrderedDict{String, Any}()
-    d["typename"]     = string(typeof(o))
+    d["typename"]     = _type_name_long(o)
     d["constructor"]  = "correlation_holder"
     d["alias"]        = serialise(o.alias)
     d["correlations"] = serialise(o.correlations)

--- a/src/termstructures/Termstructures.jl
+++ b/src/termstructures/Termstructures.jl
@@ -15,23 +15,6 @@ function alias(ts::Termstructure)
     return ts.alias
 end
 
-"""
-    @enum(
-        TermstructureResultSize,
-        TermstructureVector,
-        TermstructureScalar
-    )
-
-Specify the dimensions/shape of the values modelled by a term structure.
-
-For some term structures (e.g. `ParameterTermstructure` and
-`VolatilityTermstructure`) the result may be either a vector or a scalar.
-"""
-@enum(
-    TermstructureResultSize,
-    TermstructureVector,
-    TermstructureScalar
-)
 
 """
     abstract type CorrelationTermstructure <: Termstructure end
@@ -176,20 +159,20 @@ parameter values for various incarnations of signatures.
 abstract type ParameterTermstructure <: Termstructure end
 
 """
-    value(ts::ParameterTermstructure, result_size::TermstructureResultSize = TermstructureVector)
+    value(ts::ParameterTermstructure)
 
 Return a value for constant/time-homogeneous parameters.
 """
-function value(ts::ParameterTermstructure, result_size::TermstructureResultSize = TermstructureVector)
+function value(ts::ParameterTermstructure)
     error("ParameterTermstructure needs to implement value method.")
 end
 
 """
-    value(ts::ParameterTermstructure, t::ModelTime, result_size::TermstructureResultSize = TermstructureVector)
+    value(ts::ParameterTermstructure, t::ModelTime)
 
 Return a value for a given observation time `t`.
 """
-function value(ts::ParameterTermstructure, t::ModelTime, result_size::TermstructureResultSize = TermstructureVector)
+function value(ts::ParameterTermstructure, t::ModelTime)
     error("ParameterTermstructure needs to implement value method.")
 end
 
@@ -265,11 +248,11 @@ volatility values for various incarnations of signatures.
 abstract type VolatilityTermstructure <: Termstructure end
 
 """
-    volatility(ts::VolatilityTermstructure, t::ModelTime, result_size::TermstructureResultSize = TermstructureVector)
+    volatility(ts::VolatilityTermstructure, t::ModelTime)
 
 Return a volatility for a given observation time `t`.
 """
-function volatility(ts::VolatilityTermstructure, t::ModelTime, result_size::TermstructureResultSize = TermstructureVector)
+function volatility(ts::VolatilityTermstructure, t::ModelTime)
     error("VolatilityTermstructure needs to implement volatility method.")
 end
 

--- a/src/termstructures/correlation/CorrelationHolder.jl
+++ b/src/termstructures/correlation/CorrelationHolder.jl
@@ -1,26 +1,20 @@
 
 """
-    struct CorrelationHolder <: CorrelationTermstructure
+    struct CorrelationHolder{T<:ModelValue} <: CorrelationTermstructure
         alias::String
-        correlations::Dict{String, ModelValue}
+        correlations::Dict{String, T}
         sep::String
-        value_type::DataType
     end
 
 A container holding correlation values.
 
 A CorrelationHolder allows to calculate correlation matrices
 based on `String` alias keys (identifiers).
-
-`value_type` specifies the type of correlation entries. This ensures that
-all values are of consistent type. This feature is required for correlation
-sensitivity calculation.
 """
-struct CorrelationHolder <: CorrelationTermstructure
+struct CorrelationHolder{T<:ModelValue} <: CorrelationTermstructure
     alias::String
-    correlations::Dict{String, ModelValue}
+    correlations::Dict{String, T}
     sep::String
-    value_type::DataType
 end
 
 
@@ -38,12 +32,23 @@ function correlation_holder(
     alias::String,
     correlations::Dict,
     sep::String = "<>",
-    value_type::DataType = ModelValue,
     )
-    for (key, value) in correlations
-        @assert isa(value, value_type)
+    if (keytype(correlations) <: String) && (valtype(correlations) <: ModelValue)
+        return CorrelationHolder(alias, correlations, sep)
+    else
+        # we try to convert, e.g. Dict{Any, Any}
+        key_type = String
+        value_type = Float64
+        pattern = r"\A(.+)" * sep * r"(.+)\Z"
+        corrs = Dict{key_type, value_type}()
+        for (key, value) in correlations
+            key_ = key_type(key)
+            val_ = value_type(value)
+            @assert !isnothing(match(pattern, key_))
+            corrs[key_type(key)] = value_type(value)
+        end
+        return CorrelationHolder(alias, corrs, sep)
     end
-    return CorrelationHolder(alias, correlations, sep, value_type)
 end
 
 
@@ -60,9 +65,9 @@ Create an empty CorrelationHolder object.
 function correlation_holder(
     alias::String,
     sep::String = "<>",
-    value_type::DataType = ModelValue,
+    value_type::DataType = Float64,
     )
-    return correlation_holder(alias, Dict{String, value_type}(), sep, value_type)
+    return correlation_holder(alias, Dict{String, value_type}(), sep)
 end
 
 """
@@ -96,7 +101,7 @@ function set_correlation!(
     alias2::String,
     value::ModelValue
     )
-    @assert isa(value, ch.value_type)
+    @assert isa(value, valtype(ch.correlations))
     ch.correlations[correlation_key(ch,alias1,alias2)] = value
 end
 
@@ -107,13 +112,13 @@ Implement methodology to obtain a scalar correlation from a `CorrelationHolder`.
 """
 function get(ch::CorrelationHolder, alias1::String, alias2::String)
     if alias1 == alias2
-        return ch.value_type(1.0)
+        return valtype(ch.correlations)(1.0)
     end
     key = correlation_key(ch, alias1, alias2)
     if haskey(ch.correlations, key)
         return ch.correlations[key]
     end
-    return ch.value_type(0.0)
+    return valtype(ch.correlations)(0.0)
 end
 
 """

--- a/src/termstructures/rates/YieldTermstructures.jl
+++ b/src/termstructures/rates/YieldTermstructures.jl
@@ -1,15 +1,15 @@
 
 """
-    struct FlatForward <: YieldTermstructure
+    struct FlatForward{T<:ModelValue} <: YieldTermstructure
         alias::String
-        rate
+        rate::T
     end
 
 A constant yield term structure.
 """
-struct FlatForward <: YieldTermstructure
+struct FlatForward{T<:ModelValue} <: YieldTermstructure
     alias::String
-    rate
+    rate::T
 end
 
 """
@@ -41,21 +41,21 @@ end
 
 
 """
-    struct ZeroCurve <: YieldTermstructure
+    struct ZeroCurve{T<:ModelValue, InterpolationType} <: YieldTermstructure
         alias::String
-        times::AbstractVector
-        values::AbstractVector
-        interpolation
+        times::Vector{ModelTime}
+        values::Vector{T}
+        interpolation::InterpolationType
     end
 
 A yield term structure based on interpolated continuous
 compounded zero rates.
 """
-struct ZeroCurve <: YieldTermstructure
+struct ZeroCurve{T<:ModelValue, InterpolationType} <: YieldTermstructure
     alias::String
-    times::AbstractVector
-    values::AbstractVector
-    interpolation
+    times::Vector{ModelTime}
+    values::Vector{T}
+    interpolation::InterpolationType
 end
 
 """
@@ -143,10 +143,10 @@ end
 
 
 """
-    struct LinearZeroCurve <: YieldTermstructure
+    struct LinearZeroCurve{T<:ModelValue} <: YieldTermstructure
         alias::String
-        times::AbstractVector
-        values::AbstractVector
+        times::Vector{ModelTime}
+        values::Vector{T}
     end
 
 A yield term structure based on continuous compounded zero rates
@@ -154,10 +154,10 @@ with linear interpolation and flat extrapolation.
 
 This curve aims at mitigating limitations of Zygote and ZeroCurve.
 """
-struct LinearZeroCurve <: YieldTermstructure
+struct LinearZeroCurve{T<:ModelValue} <: YieldTermstructure
     alias::String
-    times::AbstractVector
-    values::AbstractVector
+    times::Vector{ModelTime}
+    values::Vector{T}
 end
 
 
@@ -196,11 +196,11 @@ end
 
 
 """
-    _interpole(ts::LinearZeroCurve, t::ModelTime)
+    _interpolate(ts::LinearZeroCurve, t::ModelTime)
 
-Linear  interpolation with flat exrapolation.
+Linear interpolation with flat exrapolation.
 """
-function _interpole(ts::LinearZeroCurve, t::ModelTime)
+function _interpolate(ts::LinearZeroCurve, t::ModelTime)
     idx = searchsortedfirst(ts.times, t)
      # left flat extrapolation
     if idx == 1
@@ -222,6 +222,6 @@ end
 Calculate discount factor.
 """
 function discount(ts::LinearZeroCurve, t::ModelTime)
-    z = _interpole(ts, t)
+    z = _interpolate(ts, t)
     return exp(-z * t)
 end

--- a/src/utils/Integrations.jl
+++ b/src/utils/Integrations.jl
@@ -38,14 +38,20 @@ function _norm2(x)
 end
 
 """
-    _scalar_integral(f::Function, s::ModelTime, t::ModelTime)
+    _scalar_integral(f::Any, s::ModelTime, t::ModelTime)
 
 Calculate the integral for a scalar function f in the range [s,t].
 """
-function _scalar_integral(f::Function, s::ModelTime, t::ModelTime, grid::Union{AbstractVector, Nothing} = nothing)
-    if isnothing(grid)
-        return quadgk(f, s, t)[1]
-    end
+function _scalar_integral(f::Any, s::ModelTime, t::ModelTime, grid::Nothing = nothing)
+    return quadgk(f, s, t, norm = _norm2)[1]
+end
+
+"""
+    _scalar_integral(f::Any, s::ModelTime, t::ModelTime, grid::AbstractVector)
+
+Calculate the integral for a scalar function f in the range [s,t] split using `grid`.
+"""
+function _scalar_integral(f::Any, s::ModelTime, t::ModelTime, grid::AbstractVector)
     grid = _intersect_interval(s, t, grid)
     return sum([
         quadgk(f, l, u, norm = _norm2)[1]
@@ -53,15 +59,23 @@ function _scalar_integral(f::Function, s::ModelTime, t::ModelTime, grid::Union{A
     ])
 end
 
+
 """
-    _vector_integral(f::Function, s::ModelTime, t::ModelTime)
+    _vector_integral(f::Any, s::ModelTime, t::ModelTime)
 
 Calculate the integral for a vector-valued function f in the range [s,t].
 """
-function _vector_integral(f::Function, s::ModelTime, t::ModelTime, grid::Union{AbstractVector, Nothing} = nothing)
-    if isnothing(grid)
-        return quadgk(f, s, t, norm = _norm2)[1]
-    end
+function _vector_integral(f::Any, s::ModelTime, t::ModelTime, grid::Nothing = nothing)
+    return quadgk(f, s, t, norm = _norm2)[1]
+end
+
+
+"""
+    _vector_integral(f::Any, s::ModelTime, t::ModelTime, grid::AbstractVector)
+
+Calculate the integral for a vector-valued function f in the range [s,t] split using `grid`..
+"""
+function _vector_integral(f::Any, s::ModelTime, t::ModelTime, grid::AbstractVector)
     grid = _intersect_interval(s, t, grid)
     return sum([
         quadgk(f, l, u, norm = _norm2)[1]

--- a/test/unittests/examples/simulations.jl
+++ b/test/unittests/examples/simulations.jl
@@ -26,8 +26,8 @@ using Test
         #
         @test typeof(serialised_example) == Vector{OrderedDict{String, Any}}
         @test typeof(example) == OrderedDict{String, Any}
-        @test typeof(model) == DiffFusion.SimpleModel
-        @test typeof(ch)  == DiffFusion.CorrelationHolder
+        @test isa(model, DiffFusion.SimpleModel)
+        @test typeof(ch)  == DiffFusion.CorrelationHolder{Float64}
         @test typeof(sim)  == DiffFusion.Simulation
         @test sim  == example[alias(model) * "/simulation"]
         @test typeof(ctx) == DiffFusion.Context
@@ -113,8 +113,8 @@ using Test
         #
         @test typeof(serialised_example) == Vector{OrderedDict{String, Any}}
         @test typeof(example) == OrderedDict{String, Any}
-        @test typeof(model) == DiffFusion.SimpleModel
-        @test typeof(ch)  == DiffFusion.CorrelationHolder
+        @test isa(model, DiffFusion.SimpleModel)
+        @test typeof(ch)  == DiffFusion.CorrelationHolder{Float64}
         @test typeof(sim)  == DiffFusion.Simulation
         @test sim  == example[alias(model) * "/simulation"]
         @test typeof(ctx) == DiffFusion.Context

--- a/test/unittests/models/rates/separable_hjm_model.jl
+++ b/test/unittests/models/rates/separable_hjm_model.jl
@@ -21,6 +21,15 @@ using LinearAlgebra
         @test DiffFusion.benchmark_times(m) == [ 1., 2., 5. ]
     end
 
+    @testset "Functors." begin
+        struct NoHjmAuxiliaryVariable <: DiffFusion.HjmAuxiliaryVariable end
+        struct NoHjmHybridVolatility <: DiffFusion.HjmHybridVolatility end
+        noHjmAuxiliaryVariable = NoHjmAuxiliaryVariable()
+        noHjmHybridVolatility = NoHjmHybridVolatility()
+        @test_throws ErrorException noHjmAuxiliaryVariable(2.0)
+        @test_throws ErrorException noHjmHybridVolatility(2.0)
+    end
+
     @testset "Basic model function." begin
         @test DiffFusion.H_hjm(chi,1.0,3.0) == [ exp(-0.01*2), exp(-0.10*2), exp(-0.30*2) ]
         @test DiffFusion.G_hjm(chi,1.0,3.0) == [
@@ -89,10 +98,16 @@ using LinearAlgebra
         HHfInv = DiffFusion.benchmark_times_scaling(chi,delta)
         sigmaT(u) = HHfInv * sigma_f  # This is a rates volatility without correlation!
         V = sigmaT(0.0) * transpose(sigmaT(0.0))
-        alpha(u) = -0.30 * ones(3) * 0.15  # -30% rates-FX correlation and 15% FX vol
+        #
+        struct SimpleQuantoDrift <: DiffFusion.QuantoDrift end
+        (qd::SimpleQuantoDrift)(t::DiffFusion.ModelTime) = -0.30 * ones(3) * 0.15  # -30% rates-FX correlation and 15% FX vol
+        alpha = SimpleQuantoDrift()
         #
         y0 = DiffFusion.func_y(zeros(3,3),chi,sigmaT(0.0),0.0, 1.0)  # at s=1.
-        y(u) = DiffFusion.func_y(y0,chi,sigmaT(1.0),1.0, u)
+        struct SimpleY <: DiffFusion.HjmAuxiliaryVariable end
+        (v::SimpleY)(t::DiffFusion.ModelTime) = DiffFusion.func_y(y0,chi,sigmaT(1.0),1.0, t)
+        y = SimpleY()
+        #
         s = 1.0
         t = 3.0
         #
@@ -110,6 +125,10 @@ using LinearAlgebra
         @test isapprox(theta_x, theta0 + theta1_Simpson, atol=6.e-5)
         @test isapprox(theta_x, theta0 + theta1_Simpson, rtol=2.e-2)
         #
+        struct SimpleSigmaHyb <: DiffFusion.HjmHybridVolatility end
+        (v::SimpleSigmaHyb)(t::DiffFusion.ModelTime) = HHfInv * sigma_f  # This is a rates volatility without correlation!
+        sigmaT = SimpleSigmaHyb()
+        #
         theta_s = DiffFusion.func_Theta_s(chi,y,sigmaT,alpha,s,t,nothing)
         f_s(u) = DiffFusion.G_hjm(chi,u,t)' * reshape(sum(DiffFusion.func_y(y0,chi,sigmaT(u),s,u), dims=2), (3)) -
                  DiffFusion.G_hjm(chi,u,t)' * sigmaT(u) * alpha(u)
@@ -123,13 +142,13 @@ using LinearAlgebra
         @test isapprox(theta_s, theta_s_Simpson, atol=2.e-6)
         @test isapprox(theta_s, theta_s_Simpson, rtol=4.e-3)
         #
-        theta_X = DiffFusion.func_Theta(chi,y,sigmaT,alpha,s,t,nothing)
-        @test size(theta_X) == (4,)
-        @test theta_X[1:end-1] == theta_x
-        @test theta_X[end] == theta_s
-        #
         theta_x_integrate_y = DiffFusion.func_Theta_x_integrate_y(chi,y,sigmaT,alpha,s,t,nothing)
         @test isapprox(theta_x_integrate_y, theta_x)
+        #
+        theta_X = DiffFusion.func_Theta(chi,y,sigmaT,alpha,s,t,nothing)
+        @test size(theta_X) == (4,)
+        @test theta_X[1:end-1] == theta_x_integrate_y
+        @test theta_X[end] == theta_s
     end
 
     @testset "H calculation." begin
@@ -154,7 +173,9 @@ using LinearAlgebra
     @testset "Sigma_T calculation." begin
         sigma_f = Diagonal([ 50., 75., 100. ]) * 1e-4
         HHfInv = DiffFusion.benchmark_times_scaling(chi,delta)
-        sigmaT(u) = HHfInv * sigma_f
+        struct SimpleSigmaHybForSigma <: DiffFusion.HjmHybridVolatility end
+        (v::SimpleSigmaHybForSigma)(t::DiffFusion.ModelTime) = HHfInv * sigma_f
+        sigmaT = SimpleSigmaHybForSigma()
         s = 1.0
         t = 3.0
         SigmaT = DiffFusion.func_Sigma_T(chi,sigmaT,s,t)

--- a/test/unittests/serialisation/models.jl
+++ b/test/unittests/serialisation/models.jl
@@ -648,13 +648,17 @@ using YAML
             DiffFusion.SimpleModel,
         ]
         @test [ k for k in keys(obj_dict) ] == ref_alias_list
-        @test [ typeof(v) for v in values(obj_dict) ] == ref_type_list
+        for (obj, obj_type) in zip(values(obj_dict), ref_type_list)
+            @test isa(obj, obj_type)
+        end
         # @test string(obj_dict["Std"]) == string(c) # CorrelationHolder types do not match.
         yaml_string = YAML.write(s)
         yaml_dict_list = YAML.load(yaml_string; dicttype=OrderedDict{String,Any})
         obj_dict = DiffFusion.deserialise_from_list(yaml_dict_list)
         @test [ k for k in keys(obj_dict) ] == ref_alias_list
-        @test [ typeof(v) for v in values(obj_dict) ] == ref_type_list
+        for (obj, obj_type) in zip(values(obj_dict), ref_type_list)
+            @test isa(obj, obj_type)
+        end
         @test yaml_dict_list == s
         # println(yaml_dict_list)
     end

--- a/test/unittests/serialisation/read_termstructures.jl
+++ b/test/unittests/serialisation/read_termstructures.jl
@@ -9,12 +9,17 @@ using Test
         #
         @test_throws AssertionError DiffFusion.read_parameters(file_name, ';')
         res = DiffFusion.read_parameters(file_name, ',')
-        @test isa(res, Vector{DiffFusion.ForwardFlatParameter})
+        @test isa(res, Vector)
+        for ts in res
+            @test isa(ts, DiffFusion.ForwardFlatParameter)
+        end
         @test size(res) == (9,)
         #
         res = DiffFusion.read_parameters(file_name, ',', DiffFusion.backward_flat_parameter)
-        @test !isa(res, Vector{DiffFusion.ForwardFlatParameter})
-        @test isa(res, Vector{DiffFusion.BackwardFlatParameter})
+        @test isa(res, Vector)
+        for ts in res
+            @test isa(ts, DiffFusion.BackwardFlatParameter)
+        end
         @test size(res) == (9,)
     end
 
@@ -23,7 +28,10 @@ using Test
         #
         @test_throws AssertionError DiffFusion.read_volatilities(file_name, ';')
         res = DiffFusion.read_volatilities(file_name, ',')
-        @test isa(res, Vector{DiffFusion.BackwardFlatVolatility})
+        @test isa(res, Vector)
+        for ts in res
+            @test isa(ts, DiffFusion.BackwardFlatVolatility)
+        end
         @test size(res) == (2,)
     end
 
@@ -50,7 +58,10 @@ using Test
         #
         @test_throws AssertionError DiffFusion.read_zero_curves(file_name, ';')
         res = DiffFusion.read_zero_curves(file_name, ',')
-        @test isa(res, Vector{DiffFusion.ZeroCurve})
+        @test isa(res, Vector)
+        for zc in res
+            @test isa(zc, DiffFusion.ZeroCurve)
+        end
         @test size(res) == (9,)
     end
 

--- a/test/unittests/simulations/quasi_gaussian_model.jl
+++ b/test/unittests/simulations/quasi_gaussian_model.jl
@@ -161,7 +161,7 @@ using Test
             m1, ch, sim_times, n_paths, with_progress_bar = false, # brownian_increments = DiffFusion.sobol_brownian_increments
         )
         #
-        @test maximum(abs.(sim1.X - sim0.X)) < 1.2e-12
+        @test maximum(abs.(sim1.X - sim0.X)) < 2.1e-12
     end
 
     @testset "State-dependent simulation with stochastic volatility" begin

--- a/test/unittests/termstructures/correlation/correlation.jl
+++ b/test/unittests/termstructures/correlation/correlation.jl
@@ -30,6 +30,13 @@ using LinearAlgebra
         # correlation holder from dictionary
         ch2 = DiffFusion.correlation_holder("Std", ch.correlations)
         @test ch2 == ch
+        # correlation holder from Any dictionary
+        d = Dict()
+        for (key, value) in ch.correlations
+            d[key] = value
+        end
+        ch3 = DiffFusion.correlation_holder("Std", d)
+        @test string(ch3) == string(ch)
     end
 
     @testset "Additional correlation calls" begin

--- a/test/unittests/termstructures/parameter/parameter.jl
+++ b/test/unittests/termstructures/parameter/parameter.jl
@@ -24,7 +24,7 @@ using Test
         @test DiffFusion.value(ts, 10.0) == [ 80., 50., 40., ] * 1e-4
         @test DiffFusion.value(ts, 12.0) == [ 80., 50., 40., ] * 1e-4
         #
-        @test_throws AssertionError DiffFusion.value(ts, 1.5, DiffFusion.TermstructureScalar)
+        @test_throws AssertionError DiffFusion.scalar_value(ts, 1.5)
         @test_throws AssertionError DiffFusion.backward_flat_parameter("MR", times[2:end], values)
         @test_throws AssertionError DiffFusion.backward_flat_parameter("MR", vcat([2.0], times[2:end]), values)
         #
@@ -51,7 +51,7 @@ using Test
         @test DiffFusion.value(ts,  0.0) == [ 60., ]
         @test DiffFusion.value(ts,  3.0) == [ 80., ]
         #
-        @test DiffFusion.value(ts, 1.5, DiffFusion.TermstructureScalar) == 70.
+        @test DiffFusion.scalar_value(ts, 1.5) == 70.
         @test ts(1.5) == [ 70., ]
         #
         @test_throws AssertionError DiffFusion.forward_flat_parameter("MR", times[2:end], values)
@@ -72,10 +72,10 @@ using Test
         #
         @test DiffFusion.alias(ts) == "MR"
         @test DiffFusion.value(ts, 1.5) == [ 60. ] * 1e-4
-        @test DiffFusion.value(ts, 1.5, DiffFusion.TermstructureScalar) == 60. * 1e-4
+        @test DiffFusion.scalar_value(ts, 1.5) == 60. * 1e-4
         #
         @test ts(1.5) == [ 60. ] * 1e-4
-        @test ts(1.5, DiffFusion.TermstructureScalar) == 60. * 1e-4
+        @test DiffFusion.scalar_value(ts, 1.5) == 60. * 1e-4
     end
 
     @testset "Flat parameter" begin
@@ -83,14 +83,11 @@ using Test
         #
         @test DiffFusion.alias(ts) == "MR"
         @test DiffFusion.value(ts) == [ 35. ] * 1e-4
-        @test DiffFusion.value(ts, DiffFusion.TermstructureScalar) == 35. * 1e-4
         @test DiffFusion.value(ts, 1.5) == [ 35. ] * 1e-4
-        @test DiffFusion.value(ts, 1.5, DiffFusion.TermstructureScalar) == 35. * 1e-4
+        @test DiffFusion.scalar_value(ts, 1.5) == 35. * 1e-4
         #
         @test ts() == [ 35. ] * 1e-4
-        @test ts(DiffFusion.TermstructureScalar) == 35. * 1e-4
         @test ts(1.5) == [ 35. ] * 1e-4
-        @test ts(1.5, DiffFusion.TermstructureScalar) == 35. * 1e-4
         #
         ts_simple = DiffFusion.flat_parameter(35. * 1e-4)
         @test DiffFusion.alias(ts_simple) == ""

--- a/test/unittests/termstructures/termstructures.jl
+++ b/test/unittests/termstructures/termstructures.jl
@@ -51,13 +51,9 @@ using Test
         struct NoParameterTermstructure <: DiffFusion.ParameterTermstructure end
         ts = NoParameterTermstructure()
         @test_throws ErrorException DiffFusion.value(ts)
-        @test_throws ErrorException DiffFusion.value(ts, DiffFusion.TermstructureScalar)  # as_scalar
         @test_throws ErrorException DiffFusion.value(ts, 1.0)
-        @test_throws ErrorException DiffFusion.value(ts, 1.0, DiffFusion.TermstructureScalar)  # as_scalar
         @test_throws ErrorException ts()
-        @test_throws ErrorException ts(DiffFusion.TermstructureScalar)
         @test_throws ErrorException ts(1.0)
-        @test_throws ErrorException ts(1.0, DiffFusion.TermstructureScalar)
     end
 
     @testset "Abstract YieldTermstructure" begin
@@ -71,10 +67,8 @@ using Test
         struct NoVolatilityTermstructure <: DiffFusion.VolatilityTermstructure end
         ts = NoVolatilityTermstructure()
         @test_throws ErrorException DiffFusion.volatility(ts, 1.0)
-        @test_throws ErrorException DiffFusion.volatility(ts, 1.0, DiffFusion.TermstructureScalar)  # as_scalar
         @test_throws ErrorException DiffFusion.volatility(ts, 1.0, 2.0)
         @test_throws ErrorException ts(1.0)
-        @test_throws ErrorException ts(1.0, DiffFusion.TermstructureScalar)
         @test_throws ErrorException ts(1.0, 2.0)
     end
 

--- a/test/unittests/termstructures/volatility/volatility.jl
+++ b/test/unittests/termstructures/volatility/volatility.jl
@@ -24,7 +24,7 @@ using Test
         @test DiffFusion.volatility(ts, 10.0) == [ 80., 50., 40., ] * 1e-4
         @test DiffFusion.volatility(ts, 12.0) == [ 80., 50., 40., ] * 1e-4
         #
-        @test_throws AssertionError DiffFusion.volatility(ts, 1.5, DiffFusion.TermstructureScalar)
+        @test_throws AssertionError DiffFusion.scalar_volatility(ts, 1.5)
         @test_throws AssertionError DiffFusion.backward_flat_volatility("USD", times[2:end], values)
         @test_throws AssertionError DiffFusion.backward_flat_volatility("USD", vcat([2.0], times[2:end]), values)
         #
@@ -38,10 +38,9 @@ using Test
         #
         @test DiffFusion.alias(ts) == "USD"
         @test DiffFusion.volatility(ts, 1.5) == [ 60. ] * 1e-4
-        @test DiffFusion.volatility(ts, 1.5, DiffFusion.TermstructureScalar) == 60. * 1e-4
+        @test DiffFusion.scalar_volatility(ts, 1.5) == 60. * 1e-4
         #
         @test ts(1.5) == [ 60. ] * 1e-4
-        @test ts(1.5, DiffFusion.TermstructureScalar) == 60. * 1e-4
     end
 
     @testset "Flat volatility" begin
@@ -51,10 +50,9 @@ using Test
         #
         @test DiffFusion.alias(ts) == "USD"
         @test DiffFusion.volatility(ts, 1.5) == [ 35. ] * 1e-4
-        @test DiffFusion.volatility(ts, 1.5, DiffFusion.TermstructureScalar) == 35. * 1e-4
+        @test DiffFusion.scalar_volatility(ts, 1.5) == 35. * 1e-4
         #
         @test ts(1.5) == [ 35. ] * 1e-4
-        @test ts(1.5, DiffFusion.TermstructureScalar) == 35. * 1e-4
         #
         @test string(DiffFusion.flat_volatility( 0.01 )) == string(DiffFusion.flat_volatility("", 0.01))
     end


### PR DESCRIPTION
The structs often use abstract types for the components. This impedes type stability.

With this PR, we add type parameters to structs. This also requires changing serialisations.

Furthermore, we use Functors instead of closures/unnamed functions.