### PR TITLE
Allow for integer inputs in term structure constructors

### DIFF
--- a/src/termstructures/parameter/ParameterTermstructures.jl
+++ b/src/termstructures/parameter/ParameterTermstructures.jl
@@ -46,7 +46,9 @@ function backward_flat_parameter(
         @assert(times[k]<times[k+1])
     end
     #
-    return BackwardFlatParameter(alias, Vector(times), Matrix(values))
+    times_ = [ ModelTime(t) for t in times ]
+    #
+    return BackwardFlatParameter(alias, times_, Matrix(values))
 end
 
 """
@@ -104,7 +106,9 @@ function forward_flat_parameter(
         @assert(times[k]<times[k+1])
     end
     #
-    return ForwardFlatParameter(alias, Vector(times), Matrix(values))
+    times_ = [ ModelTime(t) for t in times ]
+    #
+    return ForwardFlatParameter(alias, times_, Matrix(values))
 end
 
 """

--- a/src/termstructures/rates/YieldTermstructures.jl
+++ b/src/termstructures/rates/YieldTermstructures.jl
@@ -74,7 +74,8 @@ function zero_curve(
     values::AbstractVector,
     interp_method = (x,y) -> linear_interpolation(x, y, extrapolation_bc = Line()),
     )
-    return ZeroCurve(alias, times, values, interp_method(times, values))
+    times_ = [ ModelTime(t) for t in times ]
+    return ZeroCurve(alias, times_, values, interp_method(times, values))
 end
 
 """
@@ -175,7 +176,8 @@ function linear_zero_curve(
     times::AbstractVector,
     values::AbstractVector,
     )
-    return LinearZeroCurve(alias, times, values)
+    times_ = [ ModelTime(t) for t in times ]
+    return LinearZeroCurve(alias, times_, values)
 end
 
 

--- a/src/termstructures/volatility/VolatilityTermstructures.jl
+++ b/src/termstructures/volatility/VolatilityTermstructures.jl
@@ -41,7 +41,9 @@ function backward_flat_volatility(
         @assert(values[idx] >= 0.0)
     end
     #
-    return BackwardFlatVolatility(alias, Vector(times), Matrix(values))
+    times_ = [ ModelTime(t) for t in times ]
+    #
+    return BackwardFlatVolatility(alias, times_, Matrix(values))
 end
 
 """

--- a/test/unittests/termstructures/parameter/parameter.jl
+++ b/test/unittests/termstructures/parameter/parameter.jl
@@ -94,4 +94,21 @@ using Test
         @test ts() == [ 35. ] * 1e-4
     end
 
+    @testset "Integer as input type" begin
+        # times like [0.0, 1.0] are converted to [0, 1] by JSON3.jl
+        # this used to cause errors with DiffFusionServer
+        times =  [  1,  2,  5, 10 ]
+        values = [ 50  60  70  80 ;
+                   50  50  50  50 ;
+                   30  20  20  40 ]
+        #
+        ts = DiffFusion.backward_flat_parameter("Std", times, values)
+        @test ts.times == [ 1.0, 2.0, 5.0, 10.0 ]
+        @test ts.values == values
+        #
+        ts = DiffFusion.forward_flat_parameter("Std", times, values)
+        @test ts.times == [ 1.0, 2.0, 5.0, 10.0 ]
+        @test ts.values == values
+    end
+
 end

--- a/test/unittests/termstructures/rates/rates.jl
+++ b/test/unittests/termstructures/rates/rates.jl
@@ -94,4 +94,19 @@ using Interpolations
         @test max(abs.(Δf)...) < 4.0e-3
     end
 
+    @testset "Integer as input type" begin
+        # times like [0.0, 1.0] are converted to [0, 1] by JSON3.jl
+        # this used to cause errors with DiffFusionServer
+        times  = [1, 3, 6, 10]
+        values = [1.0, 1.0, 2.0,  3.0] .* 1e-2
+        #
+        ts = DiffFusion.zero_curve("EUR", times, values)
+        @test ts.times == [1.0, 3.0, 6.0, 10.0]
+        @test ts.values == values
+        #
+        ts = DiffFusion.linear_zero_curve("EUR", times, values)
+        @test ts.times == [1.0, 3.0, 6.0, 10.0]
+        @test ts.values == values
+    end
+
 end

--- a/test/unittests/termstructures/volatility/volatility.jl
+++ b/test/unittests/termstructures/volatility/volatility.jl
@@ -78,4 +78,17 @@ using Test
         @test DiffFusion.is_constant(ts, 0.5, 7.5) == false
     end
 
+    @testset "Integer as input type" begin
+        # times like [0.0, 1.0] are converted to [0, 1] by JSON3.jl
+        # this used to cause errors with DiffFusionServer
+        times =  [  1,  2,  5, 10 ]
+        values = [ 50  60  70  80 ;
+                   50  50  50  50 ;
+                   30  20  20  40 ]
+        #
+        ts = DiffFusion.backward_flat_volatility("USD", times, values)
+        @test ts.times == [ 1.0, 2.0, 5.0, 10.0 ]
+        @test ts.values == values
+    end
+
 end


### PR DESCRIPTION
This PR aims at fixing an error which occurs during serialisation via JSON.

Times like `[0.0, 1.0]` are converted to `[0, 1]` by JSON3.jl. This causes errors with DiffFusionServer.