### PR TITLE
Add ProcessValue payoff to inspect simulated processes

### DIFF
--- a/src/examples/yaml/g3_1factor_flat.yaml
+++ b/src/examples/yaml/g3_1factor_flat.yaml
@@ -80,6 +80,7 @@
       context_key: "NIK"
       future_model_alias: "md/NIK-FUT"
       future_index_alias: "pa/NIK-FUT"
+  processes: {}
   fixings:
     USD:SOFR:
       typename: "DiffFusion.FixingEntry"

--- a/src/examples/yaml/g3_1factor_ts.yaml
+++ b/src/examples/yaml/g3_1factor_ts.yaml
@@ -79,6 +79,7 @@
       context_key: "NIK"
       future_model_alias: "md/NIK-FUT"
       future_index_alias: "pa/NIK-FUT"
+  processes: {}
   fixings:
     USD:SOFR:
       typename: "DiffFusion.FixingEntry"

--- a/src/examples/yaml/g3_3factor_real_world.yaml
+++ b/src/examples/yaml/g3_3factor_real_world.yaml
@@ -69,6 +69,7 @@
         <empty_key> : "yc/GBP:XCCY"
   forward_indices: {}
   future_indices: {}
+  processes: {}
   fixings:
     EUR:ESTR:
       typename: "DiffFusion.FixingEntry"

--- a/src/examples/yaml/g3_3factor_ts.yaml
+++ b/src/examples/yaml/g3_3factor_ts.yaml
@@ -79,6 +79,7 @@
       context_key: "NIK"
       future_model_alias: "md/NIK-FUT"
       future_index_alias: "pa/NIK-FUT"
+  processes: {}
   fixings:
     USD:SOFR:
       typename: "DiffFusion.FixingEntry"

--- a/src/models/Model.jl
+++ b/src/models/Model.jl
@@ -160,44 +160,44 @@ Create an alias dictionary
 alias_dictionary(alias_list) = Dict([(e,k) for (k,e) in enumerate(alias_list)])
 
 """
-    log_asset(m::Model, alias::String, t::ModelTime, X::ModelState)
+    log_asset(m::Model, model_alias::String, t::ModelTime, X::ModelState)
 
 Retrieve the normalised state variable from an asset model.
 
 Returns a vector of size (p,) for X with size (n,p).
 """
-function log_asset(m::Model, alias::String, t::ModelTime, X::ModelState)
+function log_asset(m::Model, model_alias::String, t::ModelTime, X::ModelState)
     error("Model needs to implement log_asset method.")
 end
 
 """
-    log_bank_account(m::Model, alias::String, t::ModelTime, X::ModelState)
+    log_bank_account(m::Model, model_alias::String, t::ModelTime, X::ModelState)
 
 Retrieve the integral over sum of state variables s(t) from interest rate model.
 
 Returns a vector of size (p,) for X with size (n,p).
 """
-function log_bank_account(m::Model, alias::String, t::ModelTime, X::ModelState)
+function log_bank_account(m::Model, model_alias::String, t::ModelTime, X::ModelState)
     error("Model needs to implement log_bank_account method.")
 end
 
 """
-    log_zero_bond(m::Model, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+    log_zero_bond(m::Model, model_alias::String, t::ModelTime, T::ModelTime, X::ModelState)
 
 Calculate the zero bond term [G(t,T)' x(t) + 0.5 G(t,T)' y(t) G(t,T)]' from rates model.
 
 Returns a vector of size (p,) for X with size (n,p).
 """
-function log_zero_bond(m::Model, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+function log_zero_bond(m::Model, model_alias::String, t::ModelTime, T::ModelTime, X::ModelState)
     error("Model needs to implement log_compounding_factor method.")
 end
 
 """
-    log_zero_bonds(m::Model, alias::String, t::ModelTime, T::AbstractVector, X::ModelState)
+    log_zero_bonds(m::Model, model_alias::String, t::ModelTime, T::AbstractVector, X::ModelState)
 
 Calculate the zero bond terms [G(t,T)' x(t) + 0.5 G(t,T)' y(t) G(t,T)]' from rates model.
 """
-function log_zero_bonds(m::Model, alias::String, t::ModelTime, T::AbstractVector, X::ModelState)
+function log_zero_bonds(m::Model, model_alias::String, t::ModelTime, T::AbstractVector, X::ModelState)
     error("Model needs to implement log_zero_bonds method.")
 end
 
@@ -260,18 +260,34 @@ function log_asset_convexity_adjustment(
 end
 
 """
-    log_future(m::Model, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+    log_future(m::Model, model_alias::String, t::ModelTime, T::ModelTime, X::ModelState)
 
 Calculate the Future price term h(t,T)'[x(t) + 0.5y(t)(1 - h(t,T))].
 """
-function log_future(m::Model, alias::String, t::ModelTime, T::ModelTime, X::ModelState)
+function log_future(m::Model, model_alias::String, t::ModelTime, T::ModelTime, X::ModelState)
     error("Model needs to implement log_future method.")
+end
+
+
+"""
+    process_value(m::Model, model_alias::String, t::ModelTime, idx::Int, X::ModelState)
+
+Calculate the value of a stochastic process at a given time and index.
+
+We allow for multi-dimensional processes. The index `idx` is used to select the
+appropriate component of the process. Scalar processes are represented by a single
+component with `idx=1`.
+"""
+function process_value(m::Model, model_alias::String, t::ModelTime, idx::Int, X::ModelState)
+    @assert alias(m) == model_alias
+    @assert 0 < idx && idx ≤ length(state_alias(m))
+    return X(state_alias(m)[idx])
 end
 
 """
     swap_rate_variance(
         m::Model,
-        alias::String,
+        model_alias::String,
         yts::YieldTermstructure,
         t::ModelTime,
         T::ModelTime,
@@ -285,7 +301,7 @@ swap rate approximation.
 """
 function swap_rate_variance(
     m::Model,
-    alias::String,
+    model_alias::String,
     yts::YieldTermstructure,
     t::ModelTime,
     T::ModelTime,
@@ -299,7 +315,7 @@ end
 """
     forward_rate_variance(
         m::Model,
-        alias::String,
+        model_alias::String,
         t::ModelTime,
         T::ModelTime,
         T0::ModelTime,
@@ -311,7 +327,7 @@ or backward-looking forward rate.
 """
 function forward_rate_variance(
     m::Model,
-    alias::String,
+    model_alias::String,
     t::ModelTime,
     T::ModelTime,
     T0::ModelTime,

--- a/src/models/hybrid/CompositeModel.jl
+++ b/src/models/hybrid/CompositeModel.jl
@@ -42,6 +42,30 @@ function parameter_grid(m::CompositeModel)
     return parameter_grid(m.models)
 end
 
+
+
+"""
+    process_value(m::CompositeModel, model_alias::String, t::ModelTime, idx::Int, X::ModelState)
+
+Calculate the value of a stochastic process at a given time and index.
+
+If the `model_alias` does not match the alias of the composite model, we delegate to the
+component models.
+
+We allow for multi-dimensional processes. The index `idx` is used to select the
+appropriate component of the process. Scalar processes are represented by a single
+component with `idx=1`.
+"""
+function process_value(m::CompositeModel, model_alias::String, t::ModelTime, idx::Int, X::ModelState)
+    if alias(m) == model_alias
+        @assert 0 < idx && idx ≤ length(state_alias(m))
+        return X(state_alias(m)[idx])
+    end
+    # delegate to the component model
+    return process_value(m.models[m.model_dict[model_alias]], model_alias, t, idx, X)
+end
+
+
 """
     log_asset(m::CompositeModel, alias::String, t::ModelTime, X::ModelState)
 

--- a/src/paths/AbstractPath.jl
+++ b/src/paths/AbstractPath.jl
@@ -22,6 +22,22 @@ function length(p::AbstractPath)
     error("AbstractPath needs to implement length method.")
 end
 
+
+"""
+    process_value(p::AbstractPath, t::ModelTime, idx::Int, key::String)
+
+Return the value of a process at a given time. We allow for multi-dimensional
+processes. The `idx` argument specifies which component of the process.
+
+Note that simulated process is modulated by a parameter term structure.
+The `idx` argument must we within the range of the process dimension and
+parameter term structure dimension.
+"""
+function process_value(p::AbstractPath, t::ModelTime, idx::Int, key::String)
+    error("AbstractPath needs to implement process_value method.")
+end
+
+
 """
     numeraire(p::AbstractPath, t::ModelTime, curve_key::String)
 

--- a/src/paths/Context.jl
+++ b/src/paths/Context.jl
@@ -169,6 +169,29 @@ end
 
 
 """
+    struct ProcessEntry <: ContextEntry
+        context_key::String
+        process_model_alias::Union{String, Nothing}
+        process_parameter_alias::String
+    end
+
+A `ProcessEntry` represents a link to a general stochastic process (model).
+
+This entry is used to calculate future simulated values of the process.
+
+An empty `process_model_alias` (`nothing`) represents a deterministic process.
+
+`process_parameter_alias` represents the link to the parameter term structure
+representing the deterministic offset of the process.
+"""
+struct ProcessEntry <: ContextEntry
+    context_key::String
+    process_model_alias::Union{String, Nothing}
+    process_parameter_alias::String
+end
+
+
+"""
     struct FixingEntry <: ContextEntry
         context_key::String
         termstructure_alias::String
@@ -191,6 +214,7 @@ end
         assets::Dict{String, AssetEntry}
         forward_indices::Dict{String, ForwardIndexEntry}
         future_indices::Dict{String, FutureIndexEntry}
+        processes::Dict{String, ProcessEntry}
         fixings::Dict{String, FixingEntry}
     end
 
@@ -222,6 +246,7 @@ struct Context
     assets::Dict{String, AssetEntry}
     forward_indices::Dict{String, ForwardIndexEntry}
     future_indices::Dict{String, FutureIndexEntry}
+    processes::Dict{String, ProcessEntry}
     fixings::Dict{String, FixingEntry}
 end
 
@@ -470,6 +495,28 @@ end
 
 
 """
+    process_entry(
+        context_key::String,
+        process_alias::Union{String, Nothing} = nothing,
+        process_parameter_alias::Union{String, Nothing} = nothing
+        )
+
+Simplify `ProcessEntry` setup.
+"""
+function process_entry(
+    context_key::String,
+    process_alias::Union{String, Nothing} = nothing,
+    process_parameter_alias::Union{String, Nothing} = nothing
+    )
+    if isnothing(process_parameter_alias)
+        process_parameter_alias = context_key
+    end
+    return ProcessEntry(context_key, process_alias, process_parameter_alias)
+end
+
+
+
+"""
     fixing_entry(
         context_key::String,
         termstructure_alias::Union{String, Nothing} = nothing,
@@ -497,6 +544,7 @@ end
         asset_entries::Union{AbstractVector, Nothing} = nothing,
         forward_index_entries::Union{AbstractVector, Nothing} = nothing,
         future_index_entries::Union{AbstractVector, Nothing} = nothing,
+        process_entries::Union{AbstractVector, Nothing} = nothing,
         fixing_entries::Union{AbstractVector, Nothing} = nothing,
         )
 
@@ -509,6 +557,7 @@ function context(
     asset_entries::Union{AbstractVector, Nothing} = nothing,
     forward_index_entries::Union{AbstractVector, Nothing} = nothing,
     future_index_entries::Union{AbstractVector, Nothing} = nothing,
+    process_entries::Union{AbstractVector, Nothing} = nothing,
     fixing_entries::Union{AbstractVector, Nothing} = nothing,
     )
     #
@@ -532,6 +581,11 @@ function context(
     else
         future_indices = Dict{String, FutureIndexEntry}(((e.context_key, e) for e in future_index_entries))
     end
+    if isnothing(process_entries)
+        processes = Dict{String, ProcessEntry}()
+    else
+        processes = Dict{String, ProcessEntry}(((e.context_key, e) for e in process_entries))
+    end
     if isnothing(fixing_entries)
         fixings = Dict{String, FixingEntry}()
     else
@@ -544,6 +598,7 @@ function context(
         assets,
         forward_indices,
         future_indices,
+        processes,
         fixings,
         )
 end
@@ -573,6 +628,7 @@ function simple_context(alias::String, alias_list::AbstractVector)
     ]
     forward_indices = ForwardIndexEntry[]
     future_indices = FutureIndexEntry[]
+    processes = ProcessEntry[]
     fixings = FixingEntry[]
     return Context(alias,
         numeraire,
@@ -580,6 +636,7 @@ function simple_context(alias::String, alias_list::AbstractVector)
         Dict{String, AssetEntry}([(e.context_key, e) for e in assets]),
         Dict{String, ForwardIndexEntry}([(e.context_key, e) for e in forward_indices]),
         Dict{String, FutureIndexEntry}([(e.context_key, e) for e in future_indices]),
+        Dict{String, ProcessEntry}([(e.context_key, e) for e in processes]),
         Dict{String, FixingEntry}([(e.context_key, e) for e in fixings]),
     )
 end
@@ -607,12 +664,14 @@ function deterministic_model_context(alias::String, alias_list::AbstractVector)
     forward_indices = ForwardIndexEntry[]
     future_indices = FutureIndexEntry[]
     fixings = FixingEntry[]
+    processes = ProcessEntry[]
     return Context(alias,
         numeraire,
         Dict{String, RatesEntry}([(e.context_key, e) for e in rates]),
         Dict{String, AssetEntry}([(e.context_key, e) for e in assets]),
         Dict{String, ForwardIndexEntry}([(e.context_key, e) for e in forward_indices]),
         Dict{String, FutureIndexEntry}([(e.context_key, e) for e in future_indices]),
+        Dict{String, ProcessEntry}([(e.context_key, e) for e in processes]),
         Dict{String, FixingEntry}([(e.context_key, e) for e in fixings]),
     )
 end

--- a/src/paths/Path.jl
+++ b/src/paths/Path.jl
@@ -84,6 +84,10 @@ function _check_path_setup(
         @assert entry.future_index_alias in keys(ts_dict)
         @assert isa(ts_dict[entry.future_index_alias], ParameterTermstructure)
     end
+    for entry in values(cxt.processes)
+        @assert entry.process_parameter_alias in keys(ts_dict)
+        @assert isa(ts_dict[entry.process_parameter_alias], ParameterTermstructure)
+    end
     for entry in values(cxt.fixings)
         @assert entry.termstructure_alias in keys(ts_dict)
         @assert isa(ts_dict[entry.termstructure_alias], ParameterTermstructure)

--- a/src/paths/PathMethods.jl
+++ b/src/paths/PathMethods.jl
@@ -496,6 +496,33 @@ function future_index(p::Path, t::ModelTime, T::ModelTime, key::String)
     return future_index .* exp.(y)
 end
 
+"""
+    process_value(p::Path, t::ModelTime, idx::Int, key::String)
+
+Simulated process value for a given process key and index.
+"""
+function process_value(p::Path, t::ModelTime, idx::Int, key::String)
+    (context_key, ts_key_1, ts_key_2, op) = context_keys(key)
+    # term structure keys are not supported for process value
+    @assert ts_key_1 == _empty_context_key
+    @assert ts_key_2 == _empty_context_key
+    @assert op == _empty_context_key
+    #
+    entry = p.context.processes[context_key]
+    #
+    V = value(p.ts_dict[entry.process_parameter_alias], t)
+    @assert 0 < idx && idx ≤ length(V)
+    v = V[idx]
+    if isnothing(entry.process_model_alias)
+        return v .* ones(length(p))  # deterministic model
+    end
+    #
+    X = state_variable(p.sim, t, p.interpolation)
+    SX = model_state(X, p.state_alias_dict)
+    x = process_value(p.sim.model, entry.process_model_alias, t, idx, SX)
+    return v .+ x
+end
+
 
 """
     swap_rate_variance(

--- a/src/payoffs/Leafs.jl
+++ b/src/payoffs/Leafs.jl
@@ -1,5 +1,50 @@
 
 """
+    struct ProcessValue <: Leaf
+        obs_time::ModelTime
+        idx::Int
+        key::String
+    end
+
+The value of a process *X(t)* at observation time *t*.
+
+We allow for multi-dimensional processes.
+The `idx` element specifies the component of process *X*.
+"""
+struct ProcessValue <: Leaf
+    obs_time::ModelTime
+    idx::Int
+    key::String
+end
+
+
+"""
+    ProcessValue(obs_time::ModelTime, key::String)
+
+Derive the value of a scalar process *X(t)* at observation
+time *t*.
+"""
+function ProcessValue(obs_time::ModelTime, key::String)
+    return ProcessValue(obs_time, 1, key)
+end
+
+"""
+    at(p::ProcessValue, path::AbstractPath)
+
+Derive the process value at a given path.
+"""
+at(p::ProcessValue, path::AbstractPath) = process_value(path, p.obs_time, p.idx, p.key)
+
+
+"""
+    string(p::ProcessValue)
+
+Formatted (and shortened) output for ProcessValue payoff.
+"""
+string(p::ProcessValue) = @sprintf("X(%s, %.2f, %d)", p.key, p.obs_time, p.idx)
+
+
+"""
     struct Numeraire <: Leaf
         obs_time::ModelTime
         curve_key::String

--- a/src/precompile/paths.jl
+++ b/src/precompile/paths.jl
@@ -30,6 +30,10 @@ future_index_entry("NIK")
 future_index_entry("NIK", "md/NIK")
 future_index_entry("NIK", "md/NIK", "ts/NIK")
 
+process_entry("Std")
+process_entry("Std", "md/Std")
+process_entry("Std", "ts/Std")
+
 fixing_entry("SOFR")
 fixing_entry("SOFR", "ts/SOFR")
 
@@ -40,6 +44,7 @@ context(
     [ asset_entry("EUR-USD"), ],
     [ forward_index_entry("EUR-USD"), ],
     [ future_index_entry("NIK"), ],
+    [ process_entry("Std"), ],
     [ fixing_entry("SOFR"), ],
 )
 
@@ -56,6 +61,7 @@ ctx = Context("Std",
     ]),
     Dict{String, ForwardIndexEntry}(),
     Dict{String, FutureIndexEntry}(),
+    Dict{String, ProcessEntry}(),
     Dict{String, FixingEntry}(),
 )
 

--- a/test/componenttests/componenttests_fast.jl
+++ b/test/componenttests/componenttests_fast.jl
@@ -9,6 +9,7 @@ using Test
 
     include("scenarios/asset_options.jl")
     include("scenarios/bermudan_swaption.jl")
+    include("scenarios/process_value.jl")
     include("scenarios/rates_option.jl")
     include("scenarios/scenarios.jl")
     include("scenarios/swaptions_expected_exposure.jl")

--- a/test/componenttests/scenarios/bermudan_swaption.jl
+++ b/test/componenttests/scenarios/bermudan_swaption.jl
@@ -80,6 +80,7 @@ using Test
             Dict{String, DiffFusion.AssetEntry}(),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         #

--- a/test/componenttests/scenarios/process_value.jl
+++ b/test/componenttests/scenarios/process_value.jl
@@ -1,0 +1,55 @@
+using DiffFusion
+using Test
+
+
+@testset "Analyse process values via payoff." begin
+
+    example_dict = DiffFusion.Examples.load("g3_3factor_real_world")
+    example_obj = DiffFusion.Examples.build(example_dict)
+    sim = DiffFusion.Examples.simulation!(example_obj)
+    #
+    _empty_key = DiffFusion._empty_context_key
+    context = DiffFusion.Context(
+        "Std",
+        DiffFusion.NumeraireEntry("Zero", nothing, Dict(_empty_key => "yc/zero")),
+        Dict{String, DiffFusion.RatesEntry}(),
+        Dict{String, DiffFusion.AssetEntry}(),
+        Dict{String, DiffFusion.ForwardIndexEntry}(),
+        Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}([
+            ("EUR", DiffFusion.ProcessEntry("EUR", "md/EUR", "pa/zero")),
+            ("USD", DiffFusion.ProcessEntry("USD", "md/USD", "pa/zero")),
+            ("USD-EUR", DiffFusion.ProcessEntry("USD-EUR", "md/USD-EUR", "pa/zero")),
+            ("G3-EUR", DiffFusion.ProcessEntry("G3-EUR", "md/G3-EUR", "pa/zero")),
+        ]),
+        Dict{String, DiffFusion.FixingEntry}(),
+    )
+    #
+    ts_list = [
+        DiffFusion.flat_forward("yc/zero", 0.00),
+        DiffFusion.flat_parameter("pa/zero", zeros(14)),  # for G3-EUR
+    ]
+    #
+    path_ = DiffFusion.path(sim, ts_list, context)
+    #
+    p1 = DiffFusion.ProcessValue(10.0, 1, "EUR")
+    p2 = DiffFusion.ProcessValue(10.0, 4, "EUR")
+    p3 = DiffFusion.ProcessValue(10.0, 1, "USD-EUR")
+    p4 = DiffFusion.ProcessValue(10.0, 1, "USD")
+    p5 = DiffFusion.ProcessValue(10.0, 4, "USD")
+    #
+    p6 = DiffFusion.ProcessValue(10.0, 1, "G3-EUR")
+    p7 = DiffFusion.ProcessValue(10.0, 4, "G3-EUR")
+    p8 = DiffFusion.ProcessValue(10.0, 14, "G3-EUR")
+    #
+    @test p1(path_) == sim.X[1,:, 11]
+    @test p2(path_) == sim.X[4,:, 11]
+    @test p3(path_) == sim.X[5,:, 11]
+    @test p4(path_) == sim.X[6,:, 11]
+    @test p5(path_) == sim.X[9,:, 11]
+    #
+    @test p6(path_) == sim.X[1,:, 11]
+    @test p7(path_) == sim.X[4,:, 11]
+    @test p8(path_) == sim.X[14,:, 11]
+
+end

--- a/test/componenttests/scenarios/scenarios.jl
+++ b/test/componenttests/scenarios/scenarios.jl
@@ -237,6 +237,7 @@ using YAML
         ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}([
             ("USD:SOFR", DiffFusion.FixingEntry("USD:SOFR", "pa/USD:SOFR")),
             ("USD:LIB3M", DiffFusion.FixingEntry("USD:LIB3M", "pa/USD:LIB3M")),

--- a/test/componenttests/scenarios/swaptions_expected_exposure.jl
+++ b/test/componenttests/scenarios/swaptions_expected_exposure.jl
@@ -65,6 +65,7 @@ using UnicodePlots
         Dict{String, DiffFusion.AssetEntry}(),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
     

--- a/test/componenttests/sensitivities/gradients.jl
+++ b/test/componenttests/sensitivities/gradients.jl
@@ -170,6 +170,7 @@ using Test
             Dict{String, DiffFusion.AssetEntry}(),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
 

--- a/test/componenttests/sensitivities/gradients_zygote.jl
+++ b/test/componenttests/sensitivities/gradients_zygote.jl
@@ -165,6 +165,7 @@ using Test
             Dict{String, DiffFusion.AssetEntry}(),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
 

--- a/test/componenttests/sensitivities/option_vegas_zygote.jl
+++ b/test/componenttests/sensitivities/option_vegas_zygote.jl
@@ -175,6 +175,7 @@ using ForwardDiff
             Dict{String, DiffFusion.AssetEntry}(),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         #

--- a/test/componenttests/sensitivities/swaptions_delta_vega.jl
+++ b/test/componenttests/sensitivities/swaptions_delta_vega.jl
@@ -72,6 +72,7 @@ using UnicodePlots
         Dict{String, DiffFusion.AssetEntry}(),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
     

--- a/test/test_models.jl
+++ b/test/test_models.jl
@@ -81,6 +81,7 @@ context = DiffFusion.Context("Std",
     ]),
     Dict{String, DiffFusion.ForwardIndexEntry}(),
     Dict{String, DiffFusion.FutureIndexEntry}(),
+    Dict{String, DiffFusion.ProcessEntry}(),
     Dict{String, DiffFusion.FixingEntry}([
         ("USD:OIS", DiffFusion.FixingEntry("USD:OIS", "pa/USD:OIS")),
         ("EUR:OIS", DiffFusion.FixingEntry("EUR:OIS", "pa/EUR:OIS")),

--- a/test/unittests/analytics/covariances.jl
+++ b/test/unittests/analytics/covariances.jl
@@ -162,6 +162,7 @@ using Test
             ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
     

--- a/test/unittests/analytics/scenario_analytics.jl
+++ b/test/unittests/analytics/scenario_analytics.jl
@@ -49,6 +49,7 @@ using Test
         ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}([
             ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
         ]),

--- a/test/unittests/analytics/valuations.jl
+++ b/test/unittests/analytics/valuations.jl
@@ -23,6 +23,7 @@ using DifferentiationInterface
         ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
     

--- a/test/unittests/analytics/valuations_zygote.jl
+++ b/test/unittests/analytics/valuations_zygote.jl
@@ -21,6 +21,7 @@ using FiniteDifferences
         ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
     

--- a/test/unittests/models/asset/cev_asset_model.jl
+++ b/test/unittests/models/asset/cev_asset_model.jl
@@ -118,6 +118,7 @@ using Test
         X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'
         SX = DiffFusion.model_state(X, dict)
         @test DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX) == [ 2., 4., 6. ]
+        @test DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 1, SX) == [ 2., 4., 6. ]
         #
         dict = DiffFusion.alias_dictionary([ "GBP_x_1", "EUR-USD_s", "EUR_GBP_x" ])
         X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'

--- a/test/unittests/models/asset/lognormal_asset_model.jl
+++ b/test/unittests/models/asset/lognormal_asset_model.jl
@@ -81,6 +81,7 @@ using Test
         X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'
         SX = DiffFusion.model_state(X, dict)
         @test DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX) == [ 2., 4., 6. ]
+        @test DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 1, SX) == [ 2., 4., 6. ]
         #
         dict = DiffFusion.alias_dictionary([ "GBP_x_1", "EUR-USD_s", "EUR_GBP_x" ])
         X = [ 1., 2, 3 ] * [ 1., 2., 3. ]'

--- a/test/unittests/models/hybrid/simple_model.jl
+++ b/test/unittests/models/hybrid/simple_model.jl
@@ -145,6 +145,11 @@ using Test
         #
         @test DiffFusion.log_asset_convexity_adjustment(m, "USD", "EUR", "EUR-USD", 5.0, 10.0, 15.0, 20.0) == DiffFusion.log_asset_convexity_adjustment(hjm_model_dom, hjm_model_for, asset_model, 5.0, 10.0, 15.0, 20.0)
         #
+        @test DiffFusion.process_value(m, "Std", 1.0, 1, SX) == SX("USD_x_1")
+        @test DiffFusion.process_value(m, "Std", 1.0, 9, SX) == SX("NIK_x_1")
+        # process_value(.) is not delegated to component models
+        @test_throws AssertionError DiffFusion.process_value(m, "USD", 1.0, 1, SX)
+        #
         @test_throws KeyError DiffFusion.log_asset(m, "WrongAlias", 1.0, SX)
         @test_throws KeyError DiffFusion.log_bank_account(m, "WrongAlias", 1.0, SX)
         @test_throws KeyError DiffFusion.log_zero_bond(m, "WrongAlias", 4.0, 8.0, SX)

--- a/test/unittests/models/hybrid/simple_model.jl
+++ b/test/unittests/models/hybrid/simple_model.jl
@@ -147,8 +147,8 @@ using Test
         #
         @test DiffFusion.process_value(m, "Std", 1.0, 1, SX) == SX("USD_x_1")
         @test DiffFusion.process_value(m, "Std", 1.0, 9, SX) == SX("NIK_x_1")
-        # process_value(.) is not delegated to component models
-        @test_throws AssertionError DiffFusion.process_value(m, "USD", 1.0, 1, SX)
+        # process_value(.) *is* delegated to component models
+        @test DiffFusion.process_value(m, "USD", 1.0, 1, SX) == SX("USD_x_1")
         #
         @test_throws KeyError DiffFusion.log_asset(m, "WrongAlias", 1.0, SX)
         @test_throws KeyError DiffFusion.log_bank_account(m, "WrongAlias", 1.0, SX)

--- a/test/unittests/models/models.jl
+++ b/test/unittests/models/models.jl
@@ -58,6 +58,8 @@ using Test
         @test_throws ErrorException DiffFusion.forward_rate_variance(m, "alias", 1.0, 2.0, 3.0, 4.0)
         @test_throws ErrorException DiffFusion.asset_variance(m, "ast", "dom", "for", 1.0, 2.0, SX)
         #
+        @test_throws ErrorException DiffFusion.process_value(m, "alias", 1.0, 1, SX)  # due to missing alias/state_alias methods
+        #
         ch = DiffFusion.correlation_holder("Std")
         @test_throws ErrorException DiffFusion.simulation_parameters(m, ch, 1.0, 2.0)
         @test_throws ErrorException DiffFusion.diagonal_volatility(m, 1.0, 2.0, SX)

--- a/test/unittests/models/processes/ornstein_uhlenbeck_model.jl
+++ b/test/unittests/models/processes/ornstein_uhlenbeck_model.jl
@@ -45,6 +45,7 @@ using Test
         X = [ 1. ] * [ 1., 2., 3. ]'
         SX = DiffFusion.model_state(X, dict)
         @test SX("OU_x") == reshape(X, 3)
+        @test DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 1, SX) == SX("OU_x")
         @test_throws ErrorException DiffFusion.log_asset(m, DiffFusion.alias(m), 1.0, SX)
         @test_throws ErrorException DiffFusion.log_bank_account(m, DiffFusion.alias(m), 1.0, SX)
         @test_throws ErrorException DiffFusion.log_zero_bond(m, DiffFusion.alias(m), 1.0, 2.0, SX)

--- a/test/unittests/models/rates/gaussian_hjm_model.jl
+++ b/test/unittests/models/rates/gaussian_hjm_model.jl
@@ -280,6 +280,10 @@ using LinearAlgebra
         @test isapprox(dfT[:,3], DiffFusion.log_zero_bond(m, DiffFusion.alias(m), 4.0, 8.0, SX), rtol=1.0e-14)
         @test isapprox(dfT[:,4], DiffFusion.log_zero_bond(m, DiffFusion.alias(m), 4.0, 10.0, SX), rtol=1.0e-14)
         #
+        @test DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 1, SX) == SX("Theta_3F_x_1")
+        @test DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 4, SX) == SX("Theta_3F_s")
+        @test_throws AssertionError DiffFusion.process_value(m, DiffFusion.alias(m), 1.0, 5, SX)
+        #
         X = [ 0., 0., 1., 2., 3., 4., 0. ] * [ 1., 2., 3.]'
         s_alias = [ "1", "2", "Theta_3F_x_1", "Theta_3F_x_2", "Theta_3F_x_3", "Theta_3F_s", "7" ]
         dict = DiffFusion.alias_dictionary(s_alias)

--- a/test/unittests/models/rates/quasi_gaussian_model.jl
+++ b/test/unittests/models/rates/quasi_gaussian_model.jl
@@ -492,6 +492,10 @@ using Test
         @test DiffFusion.log_zero_bond(m2, "Std", s, t, SX2) == DiffFusion.log_zero_bond(m1, "Std", s, t, SX1)
         @test DiffFusion.log_zero_bonds(m2, "Std", s, T, SX2) == DiffFusion.log_zero_bonds(m1, "Std", s, T, SX1)
         @test DiffFusion.log_compounding_factor(m2, "Std", s, t1, t2, SX2) == DiffFusion.log_compounding_factor(m1, "Std", s, t1, t2, SX1)
-
+        #
+        @test DiffFusion.process_value(m2, "Std", s, 1, SX2) == SX2("Std_x_1")
+        @test DiffFusion.process_value(m2, "Std", s, 4, SX2) == SX2("Std_s")
+        @test DiffFusion.process_value(m2, "Std", s, 5, SX2) == SX2("Std_y_1_1")
+        @test DiffFusion.process_value(m2, "Std", s, 13, SX2) == SX2("Std_y_3_3")
     end
 end

--- a/test/unittests/paths/context.jl
+++ b/test/unittests/paths/context.jl
@@ -93,6 +93,22 @@ using Test
             "ts/NIK",
         ))
         #
+        @test string(DiffFusion.process_entry("Std")) == string(DiffFusion.ProcessEntry(
+            "Std",
+            nothing,
+            "Std",
+        ))
+        @test string(DiffFusion.process_entry("Std", "md/Std")) == string(DiffFusion.ProcessEntry(
+            "Std",
+            "md/Std",
+            "Std",
+        ))
+        @test string(DiffFusion.process_entry("Std", "md/Std", "ts/Std")) == string(DiffFusion.ProcessEntry(
+            "Std",
+            "md/Std",
+            "ts/Std",
+        ))
+        #
         @test string(DiffFusion.fixing_entry("SOFR")) == string(DiffFusion.FixingEntry(
             "SOFR",
             "SOFR",
@@ -121,6 +137,7 @@ using Test
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test DiffFusion.alias(c) == DiffFusion.alias(c_ref)
@@ -165,6 +182,7 @@ using Test
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}([
                 ("USD-SOFR", DiffFusion.FixingEntry("USD-SOFR", "USD-SOFR-Fixings")),
                 ("USD-LIBOR3M", DiffFusion.FixingEntry("USD-LIBOR3M", "USD-Libor3m-Fixings")),
@@ -203,6 +221,7 @@ using Test
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test string(c) == string(c_ref)
@@ -217,6 +236,7 @@ using Test
             Dict{String, DiffFusion.AssetEntry}(),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test string(ctx) == string(ctx_ref)
@@ -228,6 +248,7 @@ using Test
             [ DiffFusion.asset_entry("EUR-USD"), ],
             [ DiffFusion.forward_index_entry("EUR-USD"), ],
             [ DiffFusion.future_index_entry("NIK"), ],
+            [ DiffFusion.process_entry("Std"), ],
             [ DiffFusion.fixing_entry("SOFR"), ],
         )
         ctx_ref = DiffFusion.Context(
@@ -245,6 +266,9 @@ using Test
             ),
             Dict{String, DiffFusion.FutureIndexEntry}(
                 "NIK" => DiffFusion.future_index_entry("NIK"),
+            ),
+            Dict{String, DiffFusion.ProcessEntry}(
+                "Std" => DiffFusion.process_entry("Std"),
             ),
             Dict{String, DiffFusion.FixingEntry}(
                 "SOFR" => DiffFusion.fixing_entry("SOFR"),

--- a/test/unittests/paths/path.jl
+++ b/test/unittests/paths/path.jl
@@ -17,6 +17,7 @@ using Test
         @test_throws ErrorException DiffFusion.forward_index(NoPath(), 5.0, 10.0, "Std")
         @test_throws ErrorException DiffFusion.future_index(NoPath(), 5.0, 10.0, "Std")
         @test_throws ErrorException DiffFusion.fixing(NoPath(), 5.0, "Std")
+        @test_throws ErrorException DiffFusion.process_value(NoPath(), 5.0, 1, "Std")
         @test_throws ErrorException DiffFusion.length(NoPath())
         # not yet implemented...
         @test_throws ErrorException DiffFusion.asset_convexity_adjustment(NoPath(), 5.0, 6.0, 7.0, 8.0, "Std")
@@ -92,7 +93,9 @@ end
         Dict{String, DiffFusion.FutureIndexEntry}([
             ("NIK", DiffFusion.FutureIndexEntry("NIK", "NIK", "NIK-FUT")),
         ]),
-        Dict{String, DiffFusion.ProcessEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}([
+            ("EUR-USD", DiffFusion.ProcessEntry("EUR-USD", "EUR-USD", "EUR-USD")),
+        ]),
         Dict{String, DiffFusion.FixingEntry}([
             ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
         ]),
@@ -243,6 +246,9 @@ end
     @testset "Stochastic model functions." begin
         p = DiffFusion.path(sim, ts, context)
         t = 2.0
+        #
+        @test DiffFusion.process_value(p, t, 1, "EUR-USD")  == (1.25 + 1.0) * ones(5)
+        #
         @test isapprox(DiffFusion.numeraire(p, t, "USD"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
         @test isapprox(DiffFusion.numeraire(p, t, "USD:OIS"), exp(1.0 + 0.03*t) * ones(5), atol=1.0e-15)
         @test isapprox(DiffFusion.numeraire(p, t, "USD:OIS-OIS"), exp(1.0) * ones(5), atol=1.0e-15)
@@ -381,7 +387,7 @@ end
                 ("NIK", DiffFusion.FutureIndexEntry("NIK", nothing, "NIK-FUT")),
             ]),
             Dict{String, DiffFusion.ProcessEntry}([
-                ("Std", DiffFusion.ProcessEntry("Std", nothing, "NIK-FUT")),
+                ("EUR-USD", DiffFusion.ProcessEntry("EUR-USD", nothing, "EUR-USD")),
             ]),
             Dict{String, DiffFusion.FixingEntry}([
                 ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
@@ -391,6 +397,9 @@ end
         p = DiffFusion.path(det_sim, ts, det_context)
         t = 2.0
         T = 5.0
+        #
+        @test DiffFusion.process_value(p, t, 1, "EUR-USD") == 1.25 * ones(1)
+        #
         @test isapprox(DiffFusion.numeraire(p, t, "USD"), exp(0.03*t) * ones(1), atol=1.0e-15)
         #
         @test isapprox(DiffFusion.bank_account(p, t, "USD"), exp(0.03*t) * ones(1), atol=1.0e-15)

--- a/test/unittests/paths/path.jl
+++ b/test/unittests/paths/path.jl
@@ -92,6 +92,7 @@ end
         Dict{String, DiffFusion.FutureIndexEntry}([
             ("NIK", DiffFusion.FutureIndexEntry("NIK", "NIK", "NIK-FUT")),
         ]),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}([
             ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
         ]),
@@ -128,6 +129,7 @@ end
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
@@ -145,6 +147,7 @@ end
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
@@ -162,6 +165,7 @@ end
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         @test_throws AssertionError DiffFusion.path(sim, ts, wrong_cxt)
@@ -179,6 +183,7 @@ end
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}([
                 ("USD-SOFR", DiffFusion.FixingEntry("USD-SOFR", "USD-SOFR-Fixings")),
             ]),
@@ -375,6 +380,9 @@ end
             Dict{String, DiffFusion.FutureIndexEntry}([
                 ("NIK", DiffFusion.FutureIndexEntry("NIK", nothing, "NIK-FUT")),
             ]),
+            Dict{String, DiffFusion.ProcessEntry}([
+                ("Std", DiffFusion.ProcessEntry("Std", nothing, "NIK-FUT")),
+            ]),
             Dict{String, DiffFusion.FixingEntry}([
                 ("SOFR", DiffFusion.FixingEntry("SOFR", "USD-SOFR-Fixings")),
             ]),
@@ -450,6 +458,7 @@ end
             ]),
             Dict{String, DiffFusion.ForwardIndexEntry}(),
             Dict{String, DiffFusion.FutureIndexEntry}(),
+            Dict{String, DiffFusion.ProcessEntry}(),
             Dict{String, DiffFusion.FixingEntry}(),
         )
         p = DiffFusion.path(sim, ts, context)

--- a/test/unittests/paths/simulated_path.jl
+++ b/test/unittests/paths/simulated_path.jl
@@ -66,6 +66,7 @@ using Test
         ]),
         Dict{String, DiffFusion.ForwardIndexEntry}(),
         Dict{String, DiffFusion.FutureIndexEntry}(),
+        Dict{String, DiffFusion.ProcessEntry}(),
         Dict{String, DiffFusion.FixingEntry}(),
     )
 

--- a/test/unittests/payoffs/nodes_and_leafs.jl
+++ b/test/unittests/payoffs/nodes_and_leafs.jl
@@ -5,6 +5,7 @@ using Test
 
     "A trivial path for testing."
     struct ConstantPath <: DiffFusion.AbstractPath end
+    DiffFusion.process_value(p::ConstantPath, t::DiffFusion.ModelTime, idx::Int, key::String) = t * ones(5)
     DiffFusion.numeraire(p::ConstantPath, t::DiffFusion.ModelTime, curve_key::String) = t * ones(5)
     DiffFusion.bank_account(p::ConstantPath, t::DiffFusion.ModelTime, key::String) = 3.0 * ones(5)
     DiffFusion.zero_bond(p::ConstantPath, t::DiffFusion.ModelTime, T::DiffFusion.ModelTime, key::String) = 4.0 * ones(5)
@@ -32,6 +33,13 @@ using Test
 
     @testset "Leaf payoffs" begin
         path = ConstantPath()
+        #
+        p = DiffFusion.ProcessValue(1.0, "Std")
+        @test DiffFusion.obs_time(p) == 1.0
+        @test DiffFusion.obs_times(p) == Set(1.0)
+        @test DiffFusion.at(p, path) == 1.0 * ones(5)
+        @test p(path) == 1.0 * ones(5)
+        @test string(p) == "X(Std, 1.00, 1)"
         #
         p = DiffFusion.Numeraire(1.0, "Std")
         @test DiffFusion.obs_time(p) == 1.0

--- a/test/unittests/serialisation/models.jl
+++ b/test/unittests/serialisation/models.jl
@@ -741,6 +741,7 @@ using YAML
                 ),
             "forward_indices" => OrderedDict{String, Any}(),
             "future_indices" => OrderedDict{String, Any}(),
+            "processes" => OrderedDict{String, Any}(),
             "fixings" => OrderedDict{String, Any}(),
         )
         o = DiffFusion.deserialise(d)


### PR DESCRIPTION
With this PR, we add a ProcessValue payoff to inspect simulated processes.

The ProcessValue is linked to a new ProcessEntry link in the Context specification.

The new ProcessEntry links represent a breaking change to the Context interface.